### PR TITLE
Feature/flux limiters

### DIFF
--- a/src/Definitions/types.f90
+++ b/src/Definitions/types.f90
@@ -310,6 +310,8 @@ MODULE types
      ! Flux limiter related
      REAL*8                    :: c_fli ! Fraction of the free streaming flux used in the ion flux limiter
      REAL*8                    :: c_fle ! Fraction of the free streaming flux used in the electron flux limiter
+     REAL*8                    :: T_fluxlim_maxi ! Max ion temperature [eV] in old heat flux limiter (limiting T in T^(5/2))
+     REAL*8                    :: T_fluxlim_maxe ! Max electron temperature [eV] in old heat flux limiter (limiting T in T^(5/2))
      ! Diffusion coefficients 1D imported from file
      REAL*8, POINTER           :: rho_1D(:) => NULL() ! Radial coordinate for 1D diffusion profiles
      REAL*8, POINTER           :: diff_n_1D(:) => NULL() ! Perpendicular diffusion in the continuity equation

--- a/src/Definitions/types.f90
+++ b/src/Definitions/types.f90
@@ -307,6 +307,9 @@ MODULE types
      REAL*8                    :: ME_diff_u
      REAL*8                    :: ME_diff_e
      REAL*8                    :: ME_diff_ee
+     ! Flux limiter related
+     REAL*8                    :: c_fli ! Fraction of the free streaming flux used in the ion flux limiter
+     REAL*8                    :: c_fle ! Fraction of the free streaming flux used in the electron flux limiter
      ! Diffusion coefficients 1D imported from file
      REAL*8, POINTER           :: rho_1D(:) => NULL() ! Radial coordinate for 1D diffusion profiles
      REAL*8, POINTER           :: diff_n_1D(:) => NULL() ! Perpendicular diffusion in the continuity equation
@@ -424,6 +427,7 @@ MODULE types
      ! 1 -add sinusoidal perturbation
      ! 2 -add density blob
      LOGICAL :: logrho   ! solve for the density logarithm instead of density
+     LOGICAL :: flux_limiter ! use flux limiter for ion and electron parallel conductive heat fluxes (with provided c_fli,c_fle in physics)
      LOGICAL :: external_heating ! to read and apply external heating from input file
      LOGICAL :: impurity_radiation ! if to apply cooling factor mimicking impurity radiation, complemented by impurity name and concentration in phys
      LOGICAL :: import_diffusion_1D ! import 1D diffusion profiles from file, complemented by path in inputs

--- a/src/HDG/hdg_BC.f90
+++ b/src/HDG/hdg_BC.f90
@@ -1791,8 +1791,8 @@ CONTAINS
       CALL compute_flux_limiter(q_fs_i,q_sh_i,phys%c_fli,flux_limiter_i)
 
       ! Derivative of flux limiter
-      flux_limiter_e_ratio = ABS(q_sh_e)/q_fs_e
-      flux_limiter_i_ratio = ABS(q_sh_i)/q_fs_i
+      flux_limiter_e_ratio = ABS(q_sh_e)/q_fs_e/phys%c_fle
+      flux_limiter_i_ratio = ABS(q_sh_i)/q_fs_i/phys%c_fli
 
       fl_deriv_e = q_sh_e*flux_limiter_e_ratio/q_fs_e
       fl_deriv_i = q_sh_i*flux_limiter_i_ratio/q_fs_i
@@ -2034,8 +2034,8 @@ CONTAINS
         CALL compute_flux_limiter(q_fs_i,q_sh_i,phys%c_fli,flux_limiter_i)
 
         ! Derivative of flux limiter
-        flux_limiter_e_ratio = ABS(q_sh_e)/q_fs_e
-        flux_limiter_i_ratio = ABS(q_sh_i)/q_fs_i
+        flux_limiter_e_ratio = ABS(q_sh_e)/q_fs_e/phys%c_fle
+        flux_limiter_i_ratio = ABS(q_sh_i)/q_fs_i/phys%c_fli
 
         fl_deriv_e = q_sh_e*flux_limiter_e_ratio/q_fs_e
         fl_deriv_i = q_sh_i*flux_limiter_i_ratio/q_fs_i
@@ -2670,12 +2670,13 @@ CONTAINS
         q_sh_e = coefe*Alphae*gme
         q_sh_i = coefi*Alphai*gmi
 
-        CALL compute_flux_limiter(q_fs_i, q_sh_i, phys%c_fli, flux_limiter_i)
         CALL compute_flux_limiter(q_fs_e, q_sh_e, phys%c_fle, flux_limiter_e)
+        CALL compute_flux_limiter(q_fs_i, q_sh_i, phys%c_fli, flux_limiter_i)
+        
 
         ! Derivative of flux limiters
-        flux_limiter_i_ratio = ABS(q_sh_i)/q_fs_i
-        flux_limiter_e_ratio = ABS(q_sh_e)/q_fs_e
+        flux_limiter_e_ratio = ABS(q_sh_e)/q_fs_e/phys%c_fle
+        flux_limiter_i_ratio = ABS(q_sh_i)/q_fs_i/phys%c_fli        
 
         fl_deriv_e = q_sh_e*flux_limiter_e_ratio/q_fs_e
         fl_deriv_i = q_sh_i*flux_limiter_i_ratio/q_fs_i

--- a/src/HDG/hdg_BC.f90
+++ b/src/HDG/hdg_BC.f90
@@ -1723,6 +1723,9 @@ CONTAINS
 #else
       REAL*8           :: Vveci(Neq),Alphai,taui(Ndim,Neq),dV_dUi(Neq,Neq),gmi,dAlpha_dUi(Neq)
       REAL*8           :: Vvece(Neq),Alphae,taue(Ndim,Neq),dV_dUe(Neq,Neq),gme,dAlpha_dUe(Neq)
+      REAL*8           :: q_fs_i, q_fs_e, flux_limiter_e, flux_limiter_i, q_sh_e, q_sh_i
+      real*8           :: flux_limiter_i_ratio, flux_limiter_e_ratio, fl_deriv_i, fl_deriv_e
+      real*8           :: dq_fs_i_dU(Neq), dq_fs_e_dU(Neq)
 #endif
 
       bn = dot_PRODUCT(bg,ng)
@@ -1774,14 +1777,47 @@ CONTAINS
       CALL compute_dAlpha_dUi(ufg,dAlpha_dUi)
       CALL compute_dAlpha_dUe(ufg,dAlpha_dUe)
 
+    ! Compute flux limiters
+    IF (switch%flux_limiter) THEN
+
+      CALL compute_free_streaming_heat_flux_electrons(ufg,q_fs_e)
+      CALL compute_free_streaming_heat_flux_ions(ufg,q_fs_i)
+
+      ! Compute spitzer-Harm heat flux
+      q_sh_e = coefe*Alphae*gme
+      q_sh_i = coefi*Alphai*gmi
+
+      CALL compute_flux_limiter(q_fs_e,q_sh_e,phys%c_fle,flux_limiter_e)
+      CALL compute_flux_limiter(q_fs_i,q_sh_i,phys%c_fli,flux_limiter_i)
+
+      ! Derivative of flux limiter
+      flux_limiter_e_ratio = ABS(q_sh_e)/q_fs_e
+      flux_limiter_i_ratio = ABS(q_sh_i)/q_fs_i
+
+      fl_deriv_e = q_sh_e*flux_limiter_e_ratio/q_fs_e
+      fl_deriv_i = q_sh_i*flux_limiter_i_ratio/q_fs_i
+
+      call compute_dfree_streaming_heat_flux_electrons_dU(ufg,dq_fs_e_dU)
+      call compute_dfree_streaming_heat_flux_ions_dU(ufg,dq_fs_i_dU)
+    ELSE
+      flux_limiter_e = 1.0
+      flux_limiter_i = 1.0
+      fl_deriv_e = 0.0
+      fl_deriv_i = 0.0
+      dq_fs_e_dU = 0.0
+      dq_fs_i_dU = 0.0
+    END IF
+
     DO i = 3,4
       DO j = 1,4
         IF (i == 3) THEN
           elMat%Aul_dir(ind_fe(i + ind_asf),iel) = elMat%Aul_dir(ind_fe(i + ind_asf),iel) - &
-                    &coefi*Ni*bn*((gmi*dAlpha_dUi(j) + Alphai*(dot_PRODUCT(Taui(:,j),bg)))*ufg(j))
+                    &flux_limiter_i**2*Ni*bn*((coefi*(gmi*dAlpha_dUi(j) + Alphai*(dot_PRODUCT(Taui(:,j),bg)))+&
+                    &fl_deriv_i*dq_fs_i_dU(j))*ufg(j))
         ELSE
           elMat%Aul_dir(ind_fe(i + ind_asf),iel) = elMat%Aul_dir(ind_fe(i + ind_asf),iel) - &
-                    &coefe*Ni*bn*((gme*dAlpha_dUe(j) + Alphae*(dot_PRODUCT(Taue(:,j),bg)))*ufg(j))
+                    &flux_limiter_e**2*Ni*bn*((coefe*(gme*dAlpha_dUe(j) + Alphae*(dot_PRODUCT(Taue(:,j),bg)))+&
+                    &fl_deriv_e*dq_fs_e_dU(j))*ufg(j))
         END IF
       END DO
     END DO
@@ -1824,6 +1860,9 @@ CONTAINS
 #ifdef TEMPERATURE
         REAL*8           :: Vveci(Neq),Alphai,taui(Ndim,Neq),dV_dUi(Neq,Neq),gmi,dAlpha_dUi(Neq)
         REAL*8           :: Vvece(Neq),Alphae,taue(Ndim,Neq),dV_dUe(Neq,Neq),gme,dAlpha_dUe(Neq)
+        REAL*8           :: q_fs_i, q_fs_e, flux_limiter_e, flux_limiter_i, q_sh_e, q_sh_i
+        REAL*8           :: flux_limiter_i_ratio, flux_limiter_e_ratio, fl_deriv_i, fl_deriv_e
+        REAL*8           :: dq_fs_i_dU(Neq), dq_fs_e_dU(Neq)
         REAL*8           :: W3(Neq), dW3_dU(Neq,Neq), QdW3(Ndim,Neq)
         REAL*8           :: W4(Neq), dW4_dU(Neq,Neq), QdW4(Ndim,Neq)
 #ifdef NEUTRAL
@@ -1980,6 +2019,40 @@ CONTAINS
         gme = dot_PRODUCT(MATMUL(Qpr,Vvece),bg)             ! scalar
         Taui = MATMUL(Qpr,dV_dUi)                      ! 2x3
         Taue = MATMUL(Qpr,dV_dUe)      ! 2x3
+
+      ! Compute flux limiters
+
+      IF (switch%flux_limiter) THEN
+        CALL compute_free_streaming_heat_flux_electrons(ufg,q_fs_e)
+        CALL compute_free_streaming_heat_flux_ions(ufg,q_fs_i)
+
+        ! Compute spitzer-Harm heat flux
+          q_sh_e = coefe*Alphae*gme
+          q_sh_i = coefi*Alphai*gmi
+
+        CALL compute_flux_limiter(q_fs_e,q_sh_e,phys%c_fle,flux_limiter_e)
+        CALL compute_flux_limiter(q_fs_i,q_sh_i,phys%c_fli,flux_limiter_i)
+
+        ! Derivative of flux limiter
+        flux_limiter_e_ratio = ABS(q_sh_e)/q_fs_e
+        flux_limiter_i_ratio = ABS(q_sh_i)/q_fs_i
+
+        fl_deriv_e = q_sh_e*flux_limiter_e_ratio/q_fs_e
+        fl_deriv_i = q_sh_i*flux_limiter_i_ratio/q_fs_i
+
+        call compute_dfree_streaming_heat_flux_electrons_dU(ufg,dq_fs_e_dU)
+        call compute_dfree_streaming_heat_flux_ions_dU(ufg,dq_fs_i_dU)
+
+      
+      ELSE
+        flux_limiter_e = 1.0
+        flux_limiter_i = 1.0
+        fl_deriv_e = 0.0
+        fl_deriv_i = 0.0
+        dq_fs_e_dU = 0.0
+        dq_fs_i_dU = 0.0
+      END IF
+
 #ifdef DNNLINEARIZED
       call compute_Dnn_dU(ufg,Dnn_dU)
       Dnn_dU_u = dot_product(Dnn_dU,ufg)
@@ -2003,25 +2076,27 @@ CONTAINS
             indj = ind_asf + j
                  elMat%ALL(ind_ff(indi + 2),ind_ff(indj),iel) = elMat%ALL(ind_ff(indi + 2),ind_ff(indj),iel) + Abohm(i,j)*NiNi*bn
                  elMat%ALL(ind_ff(indi + 2),ind_ff(indj),iel) = elMat%ALL(ind_ff(indi + 2),ind_ff(indj),iel) -&
-                      &coefi*(gmi*dAlpha_dUi(j) + Alphai*(dot_PRODUCT(Taui(:,j),bg)))*NiNi*bn
+                      &flux_limiter_i**2*(coefi*(gmi*dAlpha_dUi(j) + Alphai*(dot_PRODUCT(Taui(:,j),bg)))+&
+                      &fl_deriv_i*dq_fs_i_dU(j))*NiNi*bn
             DO k = 1,Ndim
               elMat%Alq(ind_ff(indi+2),ind_fG(k+(j-1)*Ndim+ind_ash),iel) = elMat%Alq(ind_ff(indi+2),ind_fG(k+(j-1)*Ndim+ind_ash),iel) -&
-                &coefi*Alphai*Vveci(j)*bg(k)*NiNi*bn
+                &flux_limiter_i**2*coefi*Alphai*Vveci(j)*bg(k)*NiNi*bn
             END DO
           END DO
-              elMat%fh(ind_ff(indi+2),iel) = elMat%fh(ind_ff(indi+2),iel) - coefi*Alphai*( dot_PRODUCT (MATMUL(TRANSPOSE(Taui),bg),ufg)  )*Ni*bn
+              elMat%fh(ind_ff(indi+2),iel) = elMat%fh(ind_ff(indi+2),iel) - flux_limiter_i**2*coefi*Alphai*( dot_PRODUCT (MATMUL(TRANSPOSE(Taui),bg),ufg)  )*Ni*bn
         ELSE
           DO j = 1,Neq
             indj = ind_asf + j
                  elMat%ALL(ind_ff(indi + 2),ind_ff(indj),iel) = elMat%ALL(ind_ff(indi + 2),ind_ff(indj),iel) + Abohm(i,j)*NiNi*bn
                  elMat%ALL(ind_ff(indi + 2),ind_ff(indj),iel) = elMat%ALL(ind_ff(indi + 2),ind_ff(indj),iel) -&
-                      &coefe*(gme*dAlpha_dUe(j) + Alphae*(dot_PRODUCT(Taue(:,j),bg)))*NiNi*bn
+                      &flux_limiter_e**2*(coefe*(gme*dAlpha_dUe(j) + Alphae*(dot_PRODUCT(Taue(:,j),bg)))+&
+                      &fl_deriv_e*dq_fs_e_dU(j))*NiNi*bn
             DO k = 1,Ndim
               elMat%Alq(ind_ff(indi+2),ind_fG(k+(j-1)*Ndim+ind_ash),iel) = elMat%Alq(ind_ff(indi+2),ind_fG(k+(j-1)*Ndim+ind_ash),iel) -&
-                &coefe*Alphae*Vvece(j)*bg(k)*NiNi*bn
+                &flux_limiter_e**2*coefe*Alphae*Vvece(j)*bg(k)*NiNi*bn
             END DO
           END DO
-              elMat%fh(ind_ff(indi+2),iel) = elMat%fh(ind_ff(indi+2),iel) - coefe*Alphae*( dot_PRODUCT (MATMUL(TRANSPOSE(Taue),bg),ufg)  )*Ni*bn
+              elMat%fh(ind_ff(indi+2),iel) = elMat%fh(ind_ff(indi+2),iel) - flux_limiter_e**2*coefe*Alphae*( dot_PRODUCT (MATMUL(TRANSPOSE(Taue),bg),ufg)  )*Ni*bn
         ENDIF
       END DO
       !endif
@@ -2440,6 +2515,9 @@ CONTAINS
 #ifdef TEMPERATURE
         REAL*8                       :: Vveci(Neq),Alphai,taui(Ndim,Neq),dV_dUi(Neq,Neq),gmi,dAlpha_dUi(Neq)
         REAL*8                       :: Vvece(Neq),Alphae,taue(Ndim,Neq),dV_dUe(Neq,Neq),gme,dAlpha_dUe(Neq)
+        REAL*8                       :: q_fs_i, q_fs_e, flux_limiter_i, flux_limiter_e, q_sh_i, q_sh_e
+        REAL*8                       :: flux_limiter_i_ratio, flux_limiter_e_ratio, fl_deriv_e, fl_deriv_i
+        REAL*8                       :: dq_fs_i_dU(Neq), dq_fs_e_dU(Neq)
 #endif
 #ifdef NEUTRAL
         REAL*8                       :: recycling_coeff,  puff_coeff
@@ -2581,6 +2659,37 @@ CONTAINS
            Taui = MATMUL(Qpr,dV_dUi)                      ! 2x3
            Taue = MATMUL(Qpr,dV_dUe)      ! 2x3
 
+      ! Compute flux limiters
+
+      IF (switch%flux_limiter) THEN
+
+        CALL compute_free_streaming_heat_flux_electrons(ufg,q_fs_e)
+        CALL compute_free_streaming_heat_flux_ions(ufg,q_fs_i)
+
+        ! Compute spitzer-Harm heat flux limiters
+        q_sh_e = coefe*Alphae*gme
+        q_sh_i = coefi*Alphai*gmi
+
+        CALL compute_flux_limiter(q_fs_i, q_sh_i, phys%c_fli, flux_limiter_i)
+        CALL compute_flux_limiter(q_fs_e, q_sh_e, phys%c_fle, flux_limiter_e)
+
+        ! Derivative of flux limiters
+        flux_limiter_i_ratio = ABS(q_sh_i)/q_fs_i
+        flux_limiter_e_ratio = ABS(q_sh_e)/q_fs_e
+
+        fl_deriv_e = q_sh_e*flux_limiter_e_ratio/q_fs_e
+        fl_deriv_i = q_sh_i*flux_limiter_i_ratio/q_fs_i
+
+        call compute_dfree_streaming_heat_flux_electrons_dU(ufg,dq_fs_e_dU)
+        call compute_dfree_streaming_heat_flux_ions_dU(ufg,dq_fs_i_dU)
+      ELSE
+        flux_limiter_i = 1.
+        flux_limiter_e = 1.
+        fl_deriv_e = 0.
+        fl_deriv_i = 0.
+        dq_fs_i_dU = 0.
+        dq_fs_e_dU = 0.
+      END IF
       ! Parallel diffusion for temperature
       DO i = 1,2
         indi = ind_asf + i
@@ -2589,25 +2698,27 @@ CONTAINS
             indj = ind_asf + j
                     elMat%ALL(ind_ff(indi + 2),ind_ff(indj),iel) = elMat%ALL(ind_ff(indi + 2),ind_ff(indj),iel) + Abohm(i,j)*NiNi*bn
                     elMat%ALL(ind_ff(indi + 2),ind_ff(indj),iel) = elMat%ALL(ind_ff(indi + 2),ind_ff(indj),iel) -&
-                         &coefi*(gmi*dAlpha_dUi(j) + Alphai*(dot_PRODUCT(Taui(:,j),bg)))*NiNi*bn
+                         &flux_limiter_i**2*(coefi*(gmi*dAlpha_dUi(j) + Alphai*(dot_PRODUCT(Taui(:,j),bg)))+&
+                         &fl_deriv_i*dq_fs_i_dU(j))*NiNi*bn
             DO k = 1,Ndim
               elMat%Alq(ind_ff(indi+2),ind_fG(k+(j-1)*Ndim+ind_ash),iel) = elMat%Alq(ind_ff(indi+2),ind_fG(k+(j-1)*Ndim+ind_ash),iel) -&
-                &coefi*Alphai*Vveci(j)*bg(k)*NiNi*bn
+                &flux_limiter_i**2*coefi*Alphai*Vveci(j)*bg(k)*NiNi*bn
             END DO
           END DO
-                 elMat%fh(ind_ff(indi+2),iel) = elMat%fh(ind_ff(indi+2),iel) - coefi*Alphai*( dot_PRODUCT (MATMUL(TRANSPOSE(Taui),bg),ufg)  )*Ni*bn
+                 elMat%fh(ind_ff(indi+2),iel) = elMat%fh(ind_ff(indi+2),iel) - flux_limiter_i**2*coefi*Alphai*( dot_PRODUCT (MATMUL(TRANSPOSE(Taui),bg),ufg)  )*Ni*bn
         ELSE
           DO j = 1,Neq
             indj = ind_asf + j
                     elMat%ALL(ind_ff(indi + 2),ind_ff(indj),iel) = elMat%ALL(ind_ff(indi + 2),ind_ff(indj),iel) + Abohm(i,j)*NiNi*bn
                     elMat%ALL(ind_ff(indi + 2),ind_ff(indj),iel) = elMat%ALL(ind_ff(indi + 2),ind_ff(indj),iel) -&
-                         &coefe*(gme*dAlpha_dUe(j) + Alphae*(dot_PRODUCT(Taue(:,j),bg)))*NiNi*bn
+                         &flux_limiter_e**2*(coefe*(gme*dAlpha_dUe(j) + Alphae*(dot_PRODUCT(Taue(:,j),bg)))+&
+                         &fl_deriv_e*dq_fs_e_dU(j))*NiNi*bn
             DO k = 1,Ndim
               elMat%Alq(ind_ff(indi+2),ind_fG(k+(j-1)*Ndim+ind_ash),iel) = elMat%Alq(ind_ff(indi+2),ind_fG(k+(j-1)*Ndim+ind_ash),iel) -&
-                &coefe*Alphae*Vvece(j)*bg(k)*NiNi*bn
+                &flux_limiter_e**2*coefe*Alphae*Vvece(j)*bg(k)*NiNi*bn
             END DO
           END DO
-                 elMat%fh(ind_ff(indi+2),iel) = elMat%fh(ind_ff(indi+2),iel) - coefe*Alphae*( dot_PRODUCT (MATMUL(TRANSPOSE(Taue),bg),ufg)  )*Ni*bn
+                 elMat%fh(ind_ff(indi+2),iel) = elMat%fh(ind_ff(indi+2),iel) - flux_limiter_e**2*coefe*Alphae*( dot_PRODUCT (MATMUL(TRANSPOSE(Taue),bg),ufg)  )*Ni*bn
         ENDIF
       END DO
 

--- a/src/HDG/hdg_ComputeJacobian.f90
+++ b/src/HDG/hdg_ComputeJacobian.f90
@@ -2226,6 +2226,9 @@ CONTAINS
     real*8                    :: Telect
     real*8                    :: Vveci(Neq),dV_dUi(Neq,Neq),Alphai,dAlpha_dUi(Neq),gmi,taui(Ndim,Neq)
     real*8                    :: Vvece(Neq),dV_dUe(Neq,Neq),Alphae,dAlpha_dUe(Neq),gme,taue(Ndim,Neq)
+    real*8                    :: q_fs_i,q_fs_e,flux_limiter_i,flux_limiter_e, q_sh_i, q_sh_e 
+    real*8                    :: flux_limiter_i_ratio, flux_limiter_e_ratio, fl_deriv_i, fl_deriv_e
+    real*8                    :: dq_fs_i_dU(Neq), dq_fs_e_dU(Neq)
     real*8                    :: W,dW_dU(Neq,Neq),s,ds_dU(Neq),Zet(ndim,Neq)
     real*8                    :: Sohmic,dSohmic_dU(Neq) ! Ohmic heating
     real*8                    :: W3(Neq),dW3_dU(Neq,Neq),QdW3(Ndim,Neq)
@@ -2317,6 +2320,39 @@ CONTAINS
         gme = dot_PRODUCT(MATMUL(Qpr,Vvece),b)    ! scalar
         Taui = MATMUL(Qpr,dV_dUi)                 ! Ndim x Neq
         Taue = MATMUL(Qpr,dV_dUe)                 ! Ndim x Neq
+
+    ! Compute flux limiters
+
+    IF (switch%flux_limiter) THEN
+    
+      call compute_free_streaming_heat_flux_electrons(ue,q_fs_e)
+      call compute_free_streaming_heat_flux_ions(ue,q_fs_i)
+      ! Compute spitzer-harm heat fluxes
+      q_sh_e = coefe*Alphae*gme
+      q_sh_i = coefi*Alphai*gmi
+
+      call compute_flux_limiter(q_fs_e,q_sh_e,phys%c_fle,flux_limiter_e)
+      call compute_flux_limiter(q_fs_i,q_sh_i,phys%c_fli,flux_limiter_i)
+
+  
+    
+      ! Derivatives of flux limiters
+      flux_limiter_e_ratio = ABS(q_sh_e)/(q_fs_e)
+      flux_limiter_i_ratio = ABS(q_sh_i)/(q_fs_i)
+
+      fl_deriv_e = q_sh_e*flux_limiter_e_ratio/q_fs_e
+      fl_deriv_i = q_sh_i*flux_limiter_i_ratio/q_fs_i
+
+      call compute_dfree_streaming_heat_flux_electrons_dU(ue,dq_fs_e_dU)
+      call compute_dfree_streaming_heat_flux_ions_dU(ue,dq_fs_i_dU)
+    ELSE 
+      flux_limiter_e = 1.
+      flux_limiter_i = 1.
+      fl_deriv_e = 0.
+      fl_deriv_i = 0.
+      dq_fs_e_dU = 0.
+      dq_fs_i_dU = 0.
+    END IF
 
     ! Parallel current term
     ! Compute W(U^(k-1))
@@ -2596,11 +2632,11 @@ ENDIF
         ! Parallel diffusion for the temperature
         IF (i == 3) THEN
           DO j = 1,4
-                    Auu(:,:,i+(j-1)*Neq) = Auu(:,:,i+(j-1)*Neq)+coefi*(gmi*dAlpha_dUi(j) + Alphai*(dot_PRODUCT(Taui(:,j),b)))*NNxy + &
+                    Auu(:,:,i+(j-1)*Neq) = Auu(:,:,i+(j-1)*Neq)+flux_limiter_i**2*(coefi*(gmi*dAlpha_dUi(j) + Alphai*(dot_PRODUCT(Taui(:,j),b)))+fl_deriv_i*dq_fs_i_dU(j))*NNxy + &
                          &(dot_PRODUCT(Zet(:,j),b) + ds_dU(j))*NNi
             DO k = 1,Ndim
               z = i+(k-1)*Neq+(j-1)*Neq*Ndim
-              Auq(:,:,z) = Auq(:,:,z)+ coefi*Alphai*Vveci(j)*b(k)*NNxy
+              Auq(:,:,z) = Auq(:,:,z)+ flux_limiter_i**2*coefi*Alphai*Vveci(j)*b(k)*NNxy
               IF (j == 4) THEN
                 Auq(:,:,z) = Auq(:,:,z)+W*NNi*b(k)
               END IF
@@ -2612,17 +2648,18 @@ ENDIF
             END DO
                     Auu(:,:,z) = Auu(:,:,z) - (dot_PRODUCT(QdW3(:,j),b))*NNxy
           END DO
-                 rhs(:,i) = rhs(:,i) + coefi*Alphai*(dot_PRODUCT(MATMUL(TRANSPOSE(Taui),b),ue))*NNbb + s*Ni
+                 rhs(:,i) = rhs(:,i) + flux_limiter_i**2*coefi*Alphai*(dot_PRODUCT(MATMUL(TRANSPOSE(Taui),b),ue))*NNbb + s*Ni
         ELSEIF (i == 4) THEN
           DO j = 1,4
             z = i+(j-1)*Neq
-                    Auu(:,:,z)=Auu(:,:,z)+coefe*(gme*dAlpha_dUe(j) + Alphae*(dot_PRODUCT(Taue(:,j),b)))*NNxy - (dot_PRODUCT(Zet(:,j),b) + ds_dU(j))*NNi
+                    Auu(:,:,z)=Auu(:,:,z)+flux_limiter_e**2*(coefe*(gme*dAlpha_dUe(j) + Alphae*(dot_PRODUCT(Taue(:,j),b))) + fl_deriv_e*dq_fs_e_dU(j))*NNxy - &
+                    & (dot_PRODUCT(Zet(:,j),b) + ds_dU(j))*NNi 
             IF (switch%ohmicsrc) THEN
               Auu(:,:,z) = Auu(:,:,z) - dSohmic_dU(j)*(Jtor**2)*NNi
             ENDIF
             DO k = 1,Ndim
               z = i+(k-1)*Neq+(j-1)*Neq*Ndim
-              Auq(:,:,z)=Auq(:,:,z)+coefe*Alphae*Vvece(j)*b(k)*NNxy
+              Auq(:,:,z)=Auq(:,:,z)+flux_limiter_e**2*coefe*Alphae*Vvece(j)*b(k)*NNxy
               IF (j == 4) THEN
                 Auq(:,:,z)=Auq(:,:,z)- W*NNi*b(k)
               END IF
@@ -2634,7 +2671,7 @@ ENDIF
             END DO
                     Auu(:,:,z) = Auu(:,:,z) - (dot_PRODUCT(QdW4(:,j),b))*NNxy
           END DO
-                 rhs(:,i) = rhs(:,i)+coefe*Alphae*(dot_PRODUCT(MATMUL(TRANSPOSE(Taue),b),ue))*NNbb - s*Ni
+                 rhs(:,i) = rhs(:,i)+flux_limiter_e**2*coefe*Alphae*(dot_PRODUCT(MATMUL(TRANSPOSE(Taue),b),ue))*NNbb - s*Ni
           IF (switch%ohmicsrc) THEN
             rhs(:,i) = rhs(:,i) + Sohmic*(Jtor**2)*Ni
           ENDIF
@@ -2933,6 +2970,9 @@ ENDIF
 #ifdef TEMPERATURE
       real*8                    :: Vveci(Neq),dV_dUi(Neq,Neq),Alphai,dAlpha_dUi(Neq),gmi,taui(Ndim,Neq)
       real*8                    :: Vvece(Neq),dV_dUe(Neq,Neq),Alphae,dAlpha_dUe(Neq),gme,taue(Ndim,Neq)
+      real*8                    :: q_fs_i,q_fs_e,flux_limiter_i,flux_limiter_e,q_sh_i,q_sh_e
+      real*8                    :: flux_limiter_i_ratio,flux_limiter_e_ratio, fl_deriv_i, fl_deriv_e
+      real*8                    :: dq_fs_i_dU(Neq), dq_fs_e_dU(Neq)
       real*8                    :: W3(Neq),dW3_dU(Neq,Neq),QdW3(Ndim,Neq)
       real*8                    :: W4(Neq),dW4_dU(Neq,Neq),QdW4(Ndim,Neq)
 #ifdef DNNLINEARIZED
@@ -3002,6 +3042,40 @@ ENDIF
            gme = dot_PRODUCT(MATMUL(Qpr,Vvece),b)
            Taui = MATMUL(Qpr,dV_dUi)      ! 2x3
            Taue = MATMUL(Qpr,dV_dUe)      ! 2x3
+
+      ! Compute flux limiters
+
+      IF (switch%flux_limiter) THEN
+
+        CALL compute_free_streaming_heat_flux_electrons(uf,q_fs_e)
+        CALL compute_free_streaming_heat_flux_ions(uf,q_fs_i)
+
+        ! Compute spitzer-härm heat flux
+        q_sh_e = coefe*Alphae*gme
+        q_sh_i = coefi*Alphai*gmi
+
+        CALL compute_flux_limiter(q_fs_e,q_sh_e,phys%c_fle,flux_limiter_e)
+        CALL compute_flux_limiter(q_fs_i,q_sh_i,phys%c_fli,flux_limiter_i)
+
+        ! Derivative of flux limiter
+        flux_limiter_e_ratio = ABS(q_sh_e)/q_fs_e
+        flux_limiter_i_ratio = ABS(q_sh_i)/q_fs_i
+
+        fl_deriv_e = q_sh_e*flux_limiter_e_ratio/q_fs_e
+        fl_deriv_i = q_sh_i*flux_limiter_i_ratio/q_fs_i
+
+        call compute_dfree_streaming_heat_flux_electrons_dU(uf,dq_fs_e_dU)
+        call compute_dfree_streaming_heat_flux_ions_dU(uf,dq_fs_i_dU)
+
+      ELSE
+        flux_limiter_e = 1.
+        flux_limiter_i = 1.
+        fl_deriv_e = 0.
+        fl_deriv_i = 0.
+        dq_fs_e_dU = 0.
+        dq_fs_i_dU = 0.
+      END IF
+
 #ifdef DNNLINEARIZED
            CALL compute_Dnn_dU(uf,Dnn_dU)
 
@@ -3212,33 +3286,35 @@ ENDIF
         IF (i == 3) THEN
           DO j = 1,4
             ind_jf = ind_asf + j
-                    kmult = coefi*(gmi*dAlpha_dUi(j) + Alphai*(dot_PRODUCT(Taui(:,j),b)))*NNif*bn
+                    kmult = flux_limiter_i**2*(coefi*(gmi*dAlpha_dUi(j) + Alphai*(dot_PRODUCT(Taui(:,j),b))) + &
+                    & fl_deriv_i*dq_fs_i_dU(j))*NNif*bn
             elMat%Aul(ind_fe(ind_if),ind_ff(ind_jf),iel) = elMat%Aul(ind_fe(ind_if),ind_ff(ind_jf),iel) - kmult
                     elMat%ALL(ind_ff(ind_if),ind_ff(ind_jf),iel) = elMat%ALL(ind_ff(ind_if),ind_ff(ind_jf),iel) - kmult
             DO k = 1,Ndim
               ind_kf = k + (j - 1)*Ndim + ind_ash
-              kmult = coefi*Alphai*Vveci(j)*b(k)*NNif*bn
+              kmult = flux_limiter_i**2*coefi*Alphai*Vveci(j)*b(k)*NNif*bn
               elMat%Auq(ind_fe(ind_if),ind_fg(ind_kf),iel) = elMat%Auq(ind_fe(ind_if),ind_fg(ind_kf),iel) - kmult
               elMat%Alq(ind_ff(ind_if),ind_fg(ind_kf),iel) = elMat%Alq(ind_ff(ind_if),ind_fg(ind_kf),iel) - kmult
             END DO
           END DO
-                 kmultf = coefi*Alphai*(dot_PRODUCT(MATMUL(TRANSPOSE(Taui),b),uf))*Nfbn
+                 kmultf = flux_limiter_i**2*coefi*Alphai*(dot_PRODUCT(MATMUL(TRANSPOSE(Taui),b),uf))*Nfbn
           elMat%S(ind_fe(ind_if),iel) = elMat%S(ind_fe(ind_if),iel) - kmultf
           elMat%fh(ind_ff(ind_if),iel) = elMat%fh(ind_ff(ind_if),iel) - kmultf
         ELSEIF (i == 4) THEN
           DO j = 1,4
             ind_jf = ind_asf + j
-                    kmult = coefe*(gme*dAlpha_dUe(j) + Alphae*(dot_PRODUCT(Taue(:,j),b)))*NNif*bn
+                    kmult = flux_limiter_e**2*(coefe*(gme*dAlpha_dUe(j) + Alphae*(dot_PRODUCT(Taue(:,j),b)))+&
+                    +fl_deriv_e*dq_fs_e_dU(j))*NNif*bn
             elMat%Aul(ind_fe(ind_if),ind_ff(ind_jf),iel) = elMat%Aul(ind_fe(ind_if),ind_ff(ind_jf),iel) - kmult
                     elMat%ALL(ind_ff(ind_if),ind_ff(ind_jf),iel) = elMat%ALL(ind_ff(ind_if),ind_ff(ind_jf),iel) - kmult
             DO k = 1,Ndim
               ind_kf = k + (j - 1)*Ndim + ind_ash
-              kmult = coefe*Alphae*Vvece(j)*b(k)*NNif*bn
+              kmult = flux_limiter_e**2*coefe*Alphae*Vvece(j)*b(k)*NNif*bn
               elMat%Auq(ind_fe(ind_if),ind_fg(ind_kf),iel) = elMat%Auq(ind_fe(ind_if),ind_fg(ind_kf),iel) - kmult
               elMat%Alq(ind_ff(ind_if),ind_fg(ind_kf),iel) = elMat%Alq(ind_ff(ind_if),ind_fg(ind_kf),iel) - kmult
             END DO
           END DO
-                 kmultf = coefe*Alphae*(dot_PRODUCT(MATMUL(TRANSPOSE(Taue),b),uf))*Nfbn
+                 kmultf = flux_limiter_e**2*coefe*Alphae*(dot_PRODUCT(MATMUL(TRANSPOSE(Taue),b),uf))*Nfbn
           elMat%S(ind_fe(ind_if),iel) = elMat%S(ind_fe(ind_if),iel) - kmultf
           elMat%fh(ind_ff(ind_if),iel) = elMat%fh(ind_ff(ind_if),iel) - kmultf
 #ifdef DNNLINEARIZED
@@ -3373,6 +3449,9 @@ ENDIF
 #ifdef TEMPERATURE
       real*8                    :: Vveci(Neq),dV_dUi(Neq,Neq),Alphai,dAlpha_dUi(Neq),gmi,taui(Ndim,Neq)
       real*8                    :: Vvece(Neq),dV_dUe(Neq,Neq),Alphae,dAlpha_dUe(Neq),gme,taue(Ndim,Neq)
+      real*8                    :: q_fs_i,q_fs_e,flux_limiter_i,flux_limiter_e,q_sh_e,q_sh_i
+      real*8                    :: flux_limiter_i_ratio,flux_limiter_e_ratio, fl_deriv_i, fl_deriv_e
+      real*8                    :: dq_fs_i_dU(Neq), dq_fs_e_dU(Neq)  
       real*8                    :: W3(Neq), dW3_dU(Neq,Neq), QdW3(Ndim,Neq)
       real*8                    :: W4(Neq), dW4_dU(Neq,Neq), QdW4(Ndim,Neq)
 #ifdef DNNLINEARIZED
@@ -3444,6 +3523,37 @@ ENDIF
            Taui = MATMUL(Qpr,dV_dUi)               ! 2x3
            Taue = MATMUL(Qpr,dV_dUe)               ! 2x3
 
+      ! Compute flux limiters
+      IF (switch%flux_limiter) THEN
+        CALL compute_free_streaming_heat_flux_electrons(uf,q_fs_e)
+        CALL compute_free_streaming_heat_flux_ions(uf,q_fs_i)
+
+        ! compute spitzer-harm heat flux 
+        q_sh_e = coefe*Alphae*gme
+        q_sh_i = coefi*Alphai*gmi
+
+        CALL compute_flux_limiter(q_fs_e,q_sh_e,phys%c_fle, flux_limiter_e)
+        CALL compute_flux_limiter(q_fs_i,q_sh_i,phys%c_fli, flux_limiter_i)
+
+        ! Derivative of flux limiter
+        flux_limiter_e_ratio = ABS(q_sh_e)/(q_fs_e)
+        flux_limiter_i_ratio = ABS(q_sh_i)/(q_fs_i)
+
+        fl_deriv_e = q_sh_e*flux_limiter_e_ratio/q_fs_e
+        fl_deriv_i = q_sh_i*flux_limiter_i_ratio/q_fs_i
+
+        call compute_dfree_streaming_heat_flux_electrons_dU(uf,dq_fs_e_dU)
+        call compute_dfree_streaming_heat_flux_ions_dU(uf,dq_fs_i_dU)
+      
+      ELSE
+        flux_limiter_e = 1.
+        flux_limiter_i = 1.
+        fl_deriv_e = 0.
+        fl_deriv_i = 0.
+        dq_fs_e_dU = 0.
+        dq_fs_i_dU = 0.
+      END IF
+      
 #ifdef DNNLINEARIZED
            CALL compute_Dnn_dU(uf,Dnn_dU)
 
@@ -3662,31 +3772,33 @@ END IF
           DO j = 1,4
             ind_jf = ind_asf + j
                     IF (.NOT. isdir) THEN
-                       kmult = coefi*(gmi*dAlpha_dUi(j) + Alphai*(dot_PRODUCT(Taui(:,j),b)))*NNif*bn
+                       kmult = flux_limiter_i**2*(coefi*(gmi*dAlpha_dUi(j) + Alphai*(dot_PRODUCT(Taui(:,j),b)))+&
+                       &fl_deriv_i*dq_fs_i_dU(j))*NNif*bn
               elMat%Aul(ind_fe(ind_if),ind_ff(ind_jf),iel) = elMat%Aul(ind_fe(ind_if),ind_ff(ind_jf),iel) - kmult
             END IF
             DO k = 1,Ndim
               ind_kf = k + (j - 1)*Ndim + ind_ash
-              kmult = coefi*Alphai*Vveci(j)*b(k)*NNif*bn
+              kmult = flux_limiter_i**2*coefi*Alphai*Vveci(j)*b(k)*NNif*bn
               elMat%Auq(ind_fe(ind_if),ind_fg(ind_kf),iel) = elMat%Auq(ind_fe(ind_if),ind_fg(ind_kf),iel) - kmult
             END DO
           END DO
-                 kmultf = coefi*Alphai*(dot_PRODUCT(MATMUL(TRANSPOSE(Taui),b),uf))*Nfbn
+                 kmultf = flux_limiter_i**2*coefi*Alphai*(dot_PRODUCT(MATMUL(TRANSPOSE(Taui),b),uf))*Nfbn
           elMat%S(ind_fe(ind_if),iel) = elMat%S(ind_fe(ind_if),iel) - kmultf
         ELSEIF (i == 4) THEN
           DO j = 1,4
             ind_jf = ind_asf + j
                     IF (.NOT. isdir) THEN
-                       kmult = coefe*(gme*dAlpha_dUe(j) + Alphae*(dot_PRODUCT(Taue(:,j),b)))*NNif*bn
+                       kmult = flux_limiter_e**2*(coefe*(gme*dAlpha_dUe(j) + Alphae*(dot_PRODUCT(Taue(:,j),b)))+&
+                       &fl_deriv_e*dq_fs_e_dU(j))*NNif*bn
               elMat%Aul(ind_fe(ind_if),ind_ff(ind_jf),iel) = elMat%Aul(ind_fe(ind_if),ind_ff(ind_jf),iel) - kmult
             END IF
             DO k = 1,Ndim
               ind_kf = k + (j - 1)*Ndim + ind_ash
-              kmult = coefe*Alphae*Vvece(j)*b(k)*NNif*bn
+              kmult = flux_limiter_e**2*coefe*Alphae*Vvece(j)*b(k)*NNif*bn
               elMat%Auq(ind_fe(ind_if),ind_fg(ind_kf),iel) = elMat%Auq(ind_fe(ind_if),ind_fg(ind_kf),iel) - kmult
             END DO
           END DO
-                 kmultf = coefe*Alphae*(dot_PRODUCT(MATMUL(TRANSPOSE(Taue),b),uf))*Nfbn
+                 kmultf = flux_limiter_e**2*coefe*Alphae*(dot_PRODUCT(MATMUL(TRANSPOSE(Taue),b),uf))*Nfbn
           elMat%S(ind_fe(ind_if),iel) = elMat%S(ind_fe(ind_if),iel) - kmultf
 #ifdef DNNLINEARIZED
         ELSEIF (i == 5) THEN

--- a/src/HDG/hdg_ComputeJacobian.f90
+++ b/src/HDG/hdg_ComputeJacobian.f90
@@ -2337,8 +2337,8 @@ CONTAINS
   
     
       ! Derivatives of flux limiters
-      flux_limiter_e_ratio = ABS(q_sh_e)/(q_fs_e)
-      flux_limiter_i_ratio = ABS(q_sh_i)/(q_fs_i)
+      flux_limiter_e_ratio = ABS(q_sh_e)/(q_fs_e)/phys%c_fle
+      flux_limiter_i_ratio = ABS(q_sh_i)/(q_fs_i)/phys%c_fli
 
       fl_deriv_e = q_sh_e*flux_limiter_e_ratio/q_fs_e
       fl_deriv_i = q_sh_i*flux_limiter_i_ratio/q_fs_i
@@ -3058,8 +3058,8 @@ ENDIF
         CALL compute_flux_limiter(q_fs_i,q_sh_i,phys%c_fli,flux_limiter_i)
 
         ! Derivative of flux limiter
-        flux_limiter_e_ratio = ABS(q_sh_e)/q_fs_e
-        flux_limiter_i_ratio = ABS(q_sh_i)/q_fs_i
+        flux_limiter_e_ratio = ABS(q_sh_e)/q_fs_e/phys%c_fle
+        flux_limiter_i_ratio = ABS(q_sh_i)/q_fs_i/phys%c_fli
 
         fl_deriv_e = q_sh_e*flux_limiter_e_ratio/q_fs_e
         fl_deriv_i = q_sh_i*flux_limiter_i_ratio/q_fs_i
@@ -3536,8 +3536,8 @@ ENDIF
         CALL compute_flux_limiter(q_fs_i,q_sh_i,phys%c_fli, flux_limiter_i)
 
         ! Derivative of flux limiter
-        flux_limiter_e_ratio = ABS(q_sh_e)/(q_fs_e)
-        flux_limiter_i_ratio = ABS(q_sh_i)/(q_fs_i)
+        flux_limiter_e_ratio = ABS(q_sh_e)/(q_fs_e)/phys%c_fle
+        flux_limiter_i_ratio = ABS(q_sh_i)/(q_fs_i)/phys%c_fli
 
         fl_deriv_e = q_sh_e*flux_limiter_e_ratio/q_fs_e
         fl_deriv_i = q_sh_i*flux_limiter_i_ratio/q_fs_i

--- a/src/InOut/inout.f90
+++ b/src/InOut/inout.f90
@@ -948,6 +948,8 @@ CONTAINS
          CALL HDF5_real_saving(group_id2, phys%c_fli, 'c_fli')
          CALL HDF5_real_saving(group_id2, phys%c_fle, 'c_fle')
       ENDIF
+      CALL HDF5_real_saving(group_id2, phys%T_fluxlim_maxi, 'T_fluxlim_maxi')
+      CALL HDF5_real_saving(group_id2, phys%T_fluxlim_maxe, 'T_fluxlim_maxe')
       IF (switch%import_diffusion_1D) THEN 
          CALL HDF5_array1D_saving(group_id2, phys%rho_1D, SIZE(phys%rho_1D), 'rho_1D')
          CALL HDF5_array1D_saving(group_id2, phys%diff_n_1D, SIZE(phys%diff_n_1D), 'diff_n_1D')

--- a/src/InOut/inout.f90
+++ b/src/InOut/inout.f90
@@ -944,6 +944,10 @@ CONTAINS
       CALL HDF5_real_saving(group_id2, phys%Gmbohme, 'Gmbohme')
       CALL HDF5_real_saving(group_id2, phys%Potfloat, 'Potfloat')
       CALL HDF5_array1d_saving_int(group_id2, phys%bcflags, 10, 'boundary_flags')
+      IF (switch%flux_limiter) THEN
+         CALL HDF5_real_saving(group_id2, phys%c_fli, 'c_fli')
+         CALL HDF5_real_saving(group_id2, phys%c_fle, 'c_fle')
+      ENDIF
       IF (switch%import_diffusion_1D) THEN 
          CALL HDF5_array1D_saving(group_id2, phys%rho_1D, SIZE(phys%rho_1D), 'rho_1D')
          CALL HDF5_array1D_saving(group_id2, phys%diff_n_1D, SIZE(phys%diff_n_1D), 'diff_n_1D')
@@ -990,6 +994,7 @@ CONTAINS
       CALL HDF5_logical_saving(group_id2, switch%dirivortlim, 'dirivortlim')
       CALL HDF5_logical_saving(group_id2, switch%convvort, 'convvort')
       CALL HDF5_logical_saving(group_id2, switch%logrho, 'logrho')
+      CALL HDF5_logical_saving(group_id2, switch%flux_limiter, 'flux_limiter')
       CALL HDF5_logical_saving(group_id2, switch%impurity_radiation, 'impurity_radiation')
       CALL HDF5_logical_saving(group_id2, switch%external_heating, 'external_heating')
       CALL HDF5_logical_saving(group_id2, switch%import_diffusion_1D, 'import_diffusion_1D')

--- a/src/InOut/read_input.f90
+++ b/src/InOut/read_input.f90
@@ -77,6 +77,10 @@ SUBROUTINE READ_input()
   LOGICAL               :: external_heating, external_heating_from_grid
   CHARACTER(1000)       :: external_heating_path
 
+  ! flux limiter
+  LOGICAL               :: flux_limiter
+  REAL*8                :: c_fli, c_fle
+
   ! 1D diffusion
   LOGICAL               :: import_diffusion_1D
   CHARACTER(1000)       :: diffusion_1D_path
@@ -94,7 +98,7 @@ SUBROUTINE READ_input()
   ! Defining the variables to READ from the file
   NAMELIST /SWITCH_LST/ steady,read_gmsh, readMeshFromSol, set_2d_order, order_2d, gmsh2h5, axisym,external_heating, impurity_radiation, init, driftdia, driftexb, testcase, OhmicSrc, ME,diff_reverse_Ip, target_variable, RMP, Ripple, psdtime, diffred, diffmin, &
        & shockcp, limrho, difcor, thresh, filter, decoup, ckeramp, saveNR, saveTau, fixdPotLim, dirivortcore,dirivortlim, convvort,pertini,&
-       & logrho,bxgradb,import_diffusion_1D,bohm_gyrobohm
+       & logrho,bxgradb,flux_limiter,import_diffusion_1D,bohm_gyrobohm
   NAMELIST /INPUT_LST/ field_path, field_dimensions,field_from_grid,compute_from_flux,divide_by_2pi, jtor_path, jtor_dimensions,external_heating_path,external_heating_from_grid, save_folder,puff_path,puff_dimension,target_density_path,target_density_dimension,target_density_xpr_path,target_density_xpr_dimension,impurity_concentration_path,impurity_concentration_dimension,zeff_path,zeff_dimension, diffusion_1D_path
   NAMELIST /NUMER_LST/ tau,nrp,tNR,tTM,div,sc_coe,sc_sen,minrho,so_coe,df_coe,dc_coe,thr,thrpre,stab,dumpnr_min,dumpnr_max,dumpnr_width,dumpnr_n0,ntor,ptor,tmax,npartor,bohmtypebc,exbdump
   NAMELIST /ADAPT_LST/ adaptivity,shockcp_adapt, evaluator, param_est, thr_ind, quant_ind, n_quant_ind,tol_est, difference, time_adapt, NR_adapt, freq_t_adapt, freq_NR_adapt, div_adapt, rest_adapt, osc_adapt, osc_tol, osc_check, geometry_path
@@ -105,11 +109,11 @@ SUBROUTINE READ_input()
   NAMELIST /PHYS_LST/ diff_n, diff_u, diff_e, diff_ee, diff_vort, v_p, diff_nn,I_0, heating_power, heating_dr,heating_dz,heating_sigmar,heating_sigmaz,heating_equation,&
   & Re, Re_pump, apply_trim, puff,impurity_name,impurity_concentration,feedback_propotional_gain,feedback_integral_gain,feedback_derivative_gain,& 
   & feedback_propotional_gain_xpr, feedback_integral_gain_xpr, feedback_derivative_gain_xpr, cryopump_power,puff_slope, density_source, ener_source_e, ener_source_ee, sigma_source, fluxg_trunc, part_source,ener_source,Zeff, Pohmic, Tbg, bcflags, bohmth,&
-    &bohm_energy_thresh,Gmbohm, Gmbohme, a, Mref, tie, diff_pari, diff_pare, diff_pot, epn, etapar, Potfloat,diagsource
+    &bohm_energy_thresh,Gmbohm, Gmbohme, a, Mref, tie, diff_pari, diff_pare, diff_pot, epn, etapar, Potfloat,diagsource, c_fli, c_fle
 #else
   NAMELIST /PHYS_LST/ diff_n, diff_u, diff_e, diff_ee, diff_vort, v_p, diff_nn,I_0,heating_power, heating_dr,heating_dz,heating_sigmar,heating_sigmaz,heating_equation, Re, Re_pump, apply_trim, puff,impurity_name,impurity_concentration,feedback_propotional_gain,feedback_integral_gain,feedback_derivative_gain,feedback_propotional_gain_xpr, feedback_integral_gain_xpr, feedback_derivative_gain_xpr,cryopump_power,puff_slope, density_source, ener_source_e, ener_source_ee, sigma_source, fluxg_trunc, part_source,ener_source,&
   & diff_k_min, diff_k_max, k_max, Zeff,Pohmic, Tbg, bcflags, bohmth,&
-    &bohm_energy_thresh,Gmbohm, Gmbohme, a, Mref, tie, diff_pari, diff_pare, diff_pot, epn, etapar, Potfloat,diagsource
+    &bohm_energy_thresh,Gmbohm, Gmbohme, a, Mref, tie, diff_pari, diff_pare, diff_pot, epn, etapar, Potfloat,diagsource, c_fli, c_fle
 #endif
   NAMELIST /UTILS_LST/ PRINTint, dotiming, freqdisp, freqsave
   NAMELIST /LSSOLV_LST/ sollib, lstiming, kspitrace, rtol, atol, kspitmax, igz, rprecond,Nrprecond, kspnorm, kspmethd, pctype, gmresres,mglevels, mgtypeform,itmax, itrace, rest, istop, tol, kmethd, ptype,&
@@ -179,6 +183,7 @@ SUBROUTINE READ_input()
   switch%convvort         = convvort
   switch%pertini          = pertini
   switch%logrho           = logrho
+  switch%flux_limiter     = flux_limiter
   switch%bxgradb          = bxgradb
   switch%external_heating = external_heating
   switch%impurity_radiation = impurity_radiation
@@ -323,6 +328,8 @@ SUBROUTINE READ_input()
   phys%diff_pari          = diff_pari
   phys%diff_pare          = diff_pare
   phys%diff_pot           = diff_pot
+  phys%c_fli              = c_fli
+  phys%c_fle              = c_fle
   phys%epn                = epn
   phys%etapar             = etapar
   phys%Potfloat           = Potfloat
@@ -495,6 +502,11 @@ SUBROUTINE READ_input()
      PRINT *, '                - applying trim:                                      ', phys%apply_trim
      PRINT *, '                - puff coefficient in the neutral equation:           ', phys%puff
      PRINT *, '                - cryopump power coefficient in the neutral equation: ', phys%cryopump_power
+     PRINT *, '                - flux limiter applied:                               ', switch%flux_limiter
+     IF (switch%flux_limiter) THEN
+       PRINT *, '                - c_fli (ions):                                      ', phys%c_fli
+       PRINT *, '                - c_fle (electrons):                                 ', phys%c_fle
+     ENDIF
      PRINT *, '                - impurity name:                                     ', TRIM(ADJUSTL(phys%impurity_name))
      PRINT *, '                - impurity concentration:                            ', phys%impurity_concentration
      PRINT *, '                - import 1D diffusion profile:                       ', switch%import_diffusion_1D

--- a/src/InOut/read_input.f90
+++ b/src/InOut/read_input.f90
@@ -80,6 +80,7 @@ SUBROUTINE READ_input()
   ! flux limiter
   LOGICAL               :: flux_limiter
   REAL*8                :: c_fli, c_fle
+  REAL*8                :: T_fluxlim_maxi, T_fluxlim_maxe
 
   ! 1D diffusion
   LOGICAL               :: import_diffusion_1D
@@ -109,11 +110,11 @@ SUBROUTINE READ_input()
   NAMELIST /PHYS_LST/ diff_n, diff_u, diff_e, diff_ee, diff_vort, v_p, diff_nn,I_0, heating_power, heating_dr,heating_dz,heating_sigmar,heating_sigmaz,heating_equation,&
   & Re, Re_pump, apply_trim, puff,impurity_name,impurity_concentration,feedback_propotional_gain,feedback_integral_gain,feedback_derivative_gain,& 
   & feedback_propotional_gain_xpr, feedback_integral_gain_xpr, feedback_derivative_gain_xpr, cryopump_power,puff_slope, density_source, ener_source_e, ener_source_ee, sigma_source, fluxg_trunc, part_source,ener_source,Zeff, Pohmic, Tbg, bcflags, bohmth,&
-    &bohm_energy_thresh,Gmbohm, Gmbohme, a, Mref, tie, diff_pari, diff_pare, diff_pot, epn, etapar, Potfloat,diagsource, c_fli, c_fle
+    &bohm_energy_thresh,Gmbohm, Gmbohme, a, Mref, tie, diff_pari, diff_pare, diff_pot, epn, etapar, Potfloat,diagsource, c_fli, c_fle, T_fluxlim_maxi, T_fluxlim_maxe
 #else
   NAMELIST /PHYS_LST/ diff_n, diff_u, diff_e, diff_ee, diff_vort, v_p, diff_nn,I_0,heating_power, heating_dr,heating_dz,heating_sigmar,heating_sigmaz,heating_equation, Re, Re_pump, apply_trim, puff,impurity_name,impurity_concentration,feedback_propotional_gain,feedback_integral_gain,feedback_derivative_gain,feedback_propotional_gain_xpr, feedback_integral_gain_xpr, feedback_derivative_gain_xpr,cryopump_power,puff_slope, density_source, ener_source_e, ener_source_ee, sigma_source, fluxg_trunc, part_source,ener_source,&
   & diff_k_min, diff_k_max, k_max, Zeff,Pohmic, Tbg, bcflags, bohmth,&
-    &bohm_energy_thresh,Gmbohm, Gmbohme, a, Mref, tie, diff_pari, diff_pare, diff_pot, epn, etapar, Potfloat,diagsource, c_fli, c_fle
+    &bohm_energy_thresh,Gmbohm, Gmbohme, a, Mref, tie, diff_pari, diff_pare, diff_pot, epn, etapar, Potfloat,diagsource, c_fli, c_fle, T_fluxlim_maxi, T_fluxlim_maxe
 #endif
   NAMELIST /UTILS_LST/ PRINTint, dotiming, freqdisp, freqsave
   NAMELIST /LSSOLV_LST/ sollib, lstiming, kspitrace, rtol, atol, kspitmax, igz, rprecond,Nrprecond, kspnorm, kspmethd, pctype, gmresres,mglevels, mgtypeform,itmax, itrace, rest, istop, tol, kmethd, ptype,&
@@ -330,6 +331,8 @@ SUBROUTINE READ_input()
   phys%diff_pot           = diff_pot
   phys%c_fli              = c_fli
   phys%c_fle              = c_fle
+  phys%T_fluxlim_maxi     = T_fluxlim_maxi
+  phys%T_fluxlim_maxe     = T_fluxlim_maxe
   phys%epn                = epn
   phys%etapar             = etapar
   phys%Potfloat           = Potfloat
@@ -507,6 +510,8 @@ SUBROUTINE READ_input()
        PRINT *, '                - c_fli (ions):                                      ', phys%c_fli
        PRINT *, '                - c_fle (electrons):                                 ', phys%c_fle
      ENDIF
+     PRINT *, '                - T_maxi for the flux limiter:                       ', phys%T_fluxlim_maxi
+     PRINT *, '                - T_maxe for the flux limiter:                       ', phys%T_fluxlim_maxe
      PRINT *, '                - impurity name:                                     ', TRIM(ADJUSTL(phys%impurity_name))
      PRINT *, '                - impurity concentration:                            ', phys%impurity_concentration
      PRINT *, '                - import 1D diffusion profile:                       ', switch%import_diffusion_1D

--- a/src/Models/NGammaTiTe/physics.f90
+++ b/src/Models/NGammaTiTe/physics.f90
@@ -3134,7 +3134,7 @@ SUBROUTINE computeAlphaCoeff(U,Q,Vpn,res)
 #endif
 #ifdef NEUTRALP
     REAL*8              :: Dpn
-    REAL*8              :: Vpn(simpar%Neq),Qpr(simpar%Ndim,simpar%Neq)
+    REAL*8              :: Vpn(simpar%Neq)
 #endif
 #else
     REAL*8              :: tau_aux(4)
@@ -3142,6 +3142,8 @@ SUBROUTINE computeAlphaCoeff(U,Q,Vpn,res)
 #endif
     integer             :: ndim
     real*8              :: bn, bnorm,xyd(1,size(xy)),uu(1,size(uc)),qq(1,size(q))
+    REAL*8              :: q_fs_i, q_fs_e, flux_limiter_i, flux_limiter_e, q_sh_i, q_sh_e
+    REAL*8              :: Qpr(simpar%Ndim,simpar%Neq)
 
     real*8              :: U1, U2, U3, U4
     U1 = uc(1)
@@ -3156,12 +3158,26 @@ SUBROUTINE computeAlphaCoeff(U,Q,Vpn,res)
     xyd(1,:) = xy(:)
     uu(1,:) = uc(:)
     qq(1,:) = q(:)
+    Qpr = RESHAPE(q,(/simpar%Ndim,simpar%Neq/))
+    ! Compute flux limiters at the face
+    IF (switch%flux_limiter) THEN
+      call compute_free_streaming_heat_flux_electrons(uc,q_fs_e)
+      call compute_free_streaming_heat_flux_ions(uc,q_fs_i)
+      call compute_spitzer_harm_flux_electrons(uc,Qpr,b,q_sh_e)
+      call compute_spitzer_harm_flux_ions(uc,Qpr,b,q_sh_i)
+      call compute_flux_limiter(q_fs_e,q_sh_e,phys%c_fle,flux_limiter_e)
+      call compute_flux_limiter(q_fs_i,q_sh_i,phys%c_fli,flux_limiter_i)
+
+    ELSE
+      flux_limiter_e = 1.
+      flux_limiter_i = 1.
+    END IF
 
 #ifdef NEUTRALP
     ! Compute Vpn(U^(k-1))
     CALL computeVpn(uc,Vpn)
 	   ! Compute Dpn(U^(k-1))
-    Qpr = RESHAPE(q,(/simpar%Ndim,simpar%Neq/))
+    
     !CALL computeDpn(uc,Qpr,Vpn,Dpn)
 #endif
 
@@ -3263,8 +3279,8 @@ SUBROUTINE computeAlphaCoeff(U,Q,Vpn,res)
         ! Toroidal face
         tau_aux(1) = tau_aux(1) + diff_iso(1,1,1)*refElPol%ndeg/Mesh%elemSize(iel)
         tau_aux(2) = tau_aux(2) + diff_iso(2,2,1)*refElPol%ndeg/Mesh%elemSize(iel)
-          tau_aux(3) = tau_aux(3) + diff_iso(3,3,1)*refElPol%ndeg/Mesh%elemSize(iel) + ABS(bn)*phys%diff_pari*(MIN(1.,up(7)))**2.5*bnorm/uc(1)*refElPol%ndeg/Mesh%elemSize(iel)!/phys%lscale
-          tau_aux(4) = tau_aux(4) + diff_iso(4,4,1)*refElPol%ndeg/Mesh%elemSize(iel) + ABS(bn)*phys%diff_pare*(MIN(1.,up(8)))**2.5*bnorm/uc(1)*refElPol%ndeg/Mesh%elemSize(iel)!/phys%lscale
+          tau_aux(3) = tau_aux(3) + diff_iso(3,3,1)*refElPol%ndeg/Mesh%elemSize(iel) + flux_limiter_i*ABS(bn)*phys%diff_pari*(MIN(1.,up(7)))**2.5*bnorm/uc(1)*refElPol%ndeg/Mesh%elemSize(iel)!/phys%lscale
+          tau_aux(4) = tau_aux(4) + diff_iso(4,4,1)*refElPol%ndeg/Mesh%elemSize(iel) + flux_limiter_e*ABS(bn)*phys%diff_pare*(MIN(1.,up(8)))**2.5*bnorm/uc(1)*refElPol%ndeg/Mesh%elemSize(iel)!/phys%lscale
 #ifndef NEUTRALP
 #ifdef NEUTRAL
         tau_aux(5) = tau_aux(5) + diff_iso(5,5,1)*refElPol%ndeg/Mesh%elemSize(iel) !! !numer%tau(5) diff_iso(5,5,1)

--- a/src/Models/NGammaTiTe/physics.f90
+++ b/src/Models/NGammaTiTe/physics.f90
@@ -1410,8 +1410,8 @@ CONTAINS
     res = 0.d0
     
     tmin_cons = tmin/simpar%refval_temperature*3*phys%Mref/2.
-
-    IF ((U(3)-0.5*U(2)**2)/U(1)**2 > tmin_cons) THEN
+    
+    IF (U(3)/U(1) - 0.5*U(2)**2/U(1)**2  > tmin_cons) THEN
 
       res(1) = -0.5*(U(3)-2.*U(2)**2/U(1))/(U(1)*(U(3)-1./2.*U(2)**2/U(1)))
       res(2) = -3./2.*U(2)/(U(1)*(U(3)-1./2.*U(2)**2/U(1)))

--- a/src/Models/NGammaTiTe/physics.f90
+++ b/src/Models/NGammaTiTe/physics.f90
@@ -1282,8 +1282,8 @@ CONTAINS
     REAL*8 :: res, aux
     REAL*8, PARAMETER :: tol = 1.e-20
     aux = U(3)/U(1) - 0.5*U(2)**2/U(1)**2
-    IF ((2./(3.*phys%Mref)*aux > 1.) .AND. (switch%testcase .NE. 2)) THEN
-      res = (3.*phys%Mref/2)**(phys%epn)
+    IF ((2./(3.*phys%Mref)*aux > phys%T_fluxlim_maxi) .AND. (switch%testcase .NE. 2)) THEN
+      res = (3.*phys%Mref/2*phys%T_fluxlim_maxi)**(phys%epn)
     ELSE
        IF (aux<tol) aux = tol
       res = aux**phys%epn
@@ -1295,8 +1295,8 @@ CONTAINS
     REAL*8 :: res, aux
     REAL*8, PARAMETER :: tol = 1.e-20
     aux = U(4)/U(1)
-    IF ((2./(3.*phys%Mref)*aux > 1.) .AND. (switch%testcase .NE. 2)) THEN
-      res = (3.*phys%Mref/2)**(phys%epn)
+    IF ((2./(3.*phys%Mref)*aux > phys%T_fluxlim_maxe) .AND. (switch%testcase .NE. 2)) THEN
+      res = (3.*phys%Mref/2*phys%T_fluxlim_maxe)**(phys%epn)
     ELSE
        IF (aux<tol) aux = tol
       res = aux**phys%epn
@@ -1311,7 +1311,7 @@ CONTAINS
 
     aux = U(3)/U(1) - 0.5*U(2)**2/U(1)**2
 
-    IF ((2./(3.*phys%Mref)*aux > 1.) .AND. (switch%testcase .NE. 2)) THEN !! don't apply flux limiter if it is a convergence test
+    IF ((2./(3.*phys%Mref)*aux > phys%T_fluxlim_maxi) .AND. (switch%testcase .NE. 2)) THEN !! don't apply flux limiter if it is a convergence test
       res = 0.
     ELSE
        IF (aux<0) aux = tol
@@ -1331,7 +1331,7 @@ CONTAINS
 
     aux = U(4)/U(1)
 
-    IF ((2./(3.*phys%Mref)*aux > 1.) .AND. (switch%testcase .NE. 2)) THEN !! don't apply flux limiter if it is a convergence test
+    IF ((2./(3.*phys%Mref)*aux > phys%T_fluxlim_maxe) .AND. (switch%testcase .NE. 2)) THEN !! don't apply flux limiter if it is a convergence test
       res = 0.
     ELSE
        IF (aux<0) aux = tol
@@ -3279,8 +3279,8 @@ SUBROUTINE computeAlphaCoeff(U,Q,Vpn,res)
         ! Toroidal face
         tau_aux(1) = tau_aux(1) + diff_iso(1,1,1)*refElPol%ndeg/Mesh%elemSize(iel)
         tau_aux(2) = tau_aux(2) + diff_iso(2,2,1)*refElPol%ndeg/Mesh%elemSize(iel)
-          tau_aux(3) = tau_aux(3) + diff_iso(3,3,1)*refElPol%ndeg/Mesh%elemSize(iel) + flux_limiter_i*ABS(bn)*phys%diff_pari*(MIN(1.,up(7)))**2.5*bnorm/uc(1)*refElPol%ndeg/Mesh%elemSize(iel)!/phys%lscale
-          tau_aux(4) = tau_aux(4) + diff_iso(4,4,1)*refElPol%ndeg/Mesh%elemSize(iel) + flux_limiter_e*ABS(bn)*phys%diff_pare*(MIN(1.,up(8)))**2.5*bnorm/uc(1)*refElPol%ndeg/Mesh%elemSize(iel)!/phys%lscale
+          tau_aux(3) = tau_aux(3) + diff_iso(3,3,1)*refElPol%ndeg/Mesh%elemSize(iel) + flux_limiter_i*ABS(bn)*phys%diff_pari*(MIN(phys%T_fluxlim_maxi,up(7)))**2.5*bnorm/uc(1)*refElPol%ndeg/Mesh%elemSize(iel)!/phys%lscale
+          tau_aux(4) = tau_aux(4) + diff_iso(4,4,1)*refElPol%ndeg/Mesh%elemSize(iel) + flux_limiter_e*ABS(bn)*phys%diff_pare*(MIN(phys%T_fluxlim_maxe,up(8)))**2.5*bnorm/uc(1)*refElPol%ndeg/Mesh%elemSize(iel)!/phys%lscale
 #ifndef NEUTRALP
 #ifdef NEUTRAL
         tau_aux(5) = tau_aux(5) + diff_iso(5,5,1)*refElPol%ndeg/Mesh%elemSize(iel) !! !numer%tau(5) diff_iso(5,5,1)

--- a/src/Models/NGammaTiTe/physics.f90
+++ b/src/Models/NGammaTiTe/physics.f90
@@ -1342,6 +1342,128 @@ CONTAINS
     ENDIF
   ENDSUBROUTINE compute_dAlpha_dUe
 
+  SUBROUTINE compute_free_streaming_heat_flux_electrons(U, qfs)
+    REAL*8, INTENT(IN)  :: U(:)
+    REAL*8, INTENT(OUT) :: qfs
+    REAL*8, PARAMETER :: tmin = 1e-5 ! eV    
+    REAL*8            :: tmin_cons
+    REAL*8, PARAMETER :: mi = 3.35e-27         ! Ionic mass [kg]
+    REAL*8, PARAMETER :: me = 9.109e-31        ! Electronic mass [kg]
+    REAL*8             :: t, n
+
+    tmin_cons = tmin/simpar%refval_temperature*3*phys%Mref/2.
+    
+
+    t = MAX(U(4)/U(1), tmin_cons)
+    n = U(1)
+    
+
+    qfs = (2./3.)**1.5*SQRT(mi/me)*t**1.5*n
+
+
+  END SUBROUTINE
+
+  SUBROUTINE compute_dfree_streaming_heat_flux_electrons_dU(U, res)
+    REAL*8, INTENT(IN)  :: U(:)
+    REAL*8, INTENT(OUT) :: res(:)
+    REAL*8, PARAMETER :: mi = 3.35e-27         ! Ionic mass [kg]
+    REAL*8, PARAMETER :: me = 9.109e-31        ! Electronic mass [kg]
+    REAL*8, PARAMETER :: tmin = 1e-5 ! eV    
+    REAL*8            :: tmin_cons
+
+    res = 0.d0
+
+    tmin_cons = tmin/simpar%refval_temperature*3*phys%Mref/2.
+    
+    IF (U(4)/U(1) > tmin_cons) THEN
+      res(1) = -0.5/U(1)
+      res(4) = 3./2./U(4)
+      res = (2./3.*U(4)/U(1))**1.5*U(1)*SQRT(mi/me)*res
+    ENDIF
+  END SUBROUTINE
+
+  SUBROUTINE compute_free_streaming_heat_flux_ions(U,qfs)
+    REAL*8, INTENT(IN)  :: U(:)
+    REAL*8, INTENT(OUT) :: qfs
+    REAL*8, PARAMETER :: tmin = 1e-5 ! eV    
+    REAL*8            :: tmin_cons
+    REAL*8             :: t, n
+
+    tmin_cons = tmin/simpar%refval_temperature*3*phys%Mref/2.
+
+    t = MAX(U(3)/U(1) - 0.5*U(2)**2/U(1)**2, tmin_cons)
+    n = U(1)
+
+
+
+    qfs = (2./3.)**1.5*t**1.5*n
+
+
+  END SUBROUTINE
+
+  SUBROUTINE compute_dfree_streaming_heat_flux_ions_dU(U, res)
+    REAL*8, INTENT(IN)  :: U(:)
+    REAL*8, INTENT(OUT) :: res(:)
+    REAL*8, PARAMETER :: tmin = 1e-5 ! eV    
+    REAL*8            :: tmin_cons
+
+    res = 0.d0
+    
+    tmin_cons = tmin/simpar%refval_temperature*3*phys%Mref/2.
+
+    IF ((U(3)-0.5*U(2)**2)/U(1)**2 > tmin_cons) THEN
+
+      res(1) = -0.5*(U(3)-2.*U(2)**2/U(1))/(U(1)*(U(3)-1./2.*U(2)**2/U(1)))
+      res(2) = -3./2.*U(2)/(U(1)*(U(3)-1./2.*U(2)**2/U(1)))
+      res(3) = 3./2./(U(3)-1./2.*U(2)**2/U(1))
+      res = (2./3.*(U(3)-1./2.*U(2)**2/U(1))/U(1))**1.5*U(1)*res
+    ENDIF
+  END SUBROUTINE
+
+  SUBROUTINE compute_spitzer_harm_flux_ions(U, Q, b, q_sh_i)
+    REAL*8, INTENT(IN) :: U(:), Q(:,:), b(:)
+    REAL*8, INTENT(OUT):: q_sh_i
+    REAL*8             :: Alphai, gmi, coefi
+    REAL*8             :: Vveci(SIZE(U))
+
+    coefi = phys%diff_pari*(2./(3.*phys%Mref))**(1 + phys%epn)
+    Alphai = computeAlphai(U)
+    CALL computeVi(U, Vveci)
+    gmi = dot_PRODUCT(MATMUL(Q,Vveci),b)
+    q_sh_i = -coefi*Alphai*gmi
+  
+  END SUBROUTINE compute_spitzer_harm_flux_ions
+
+  SUBROUTINE compute_spitzer_harm_flux_electrons(U, Q, b, q_sh_e)
+    REAL*8, INTENT(IN) :: U(:), Q(:,:), b(:)
+    REAL*8, INTENT(OUT):: q_sh_e
+    REAL*8             :: Alphae, gme, coefe
+    REAL*8             :: Vvece(SIZE(U))
+
+    coefe = phys%diff_pare*(2./(3.*phys%Mref))**(1 + phys%epn)
+    Alphae = computeAlphae(U)
+    CALL computeVe(U, Vvece)
+    gme = dot_PRODUCT(MATMUL(Q,Vvece),b)
+    q_sh_e = -coefe*Alphae*gme
+
+  END SUBROUTINE compute_spitzer_harm_flux_electrons
+
+  SUBROUTINE compute_flux_limiter(qfs,qsh,c_fl, flux_limiter)
+    REAL*8, INTENT(IN)  :: qfs, qsh, c_fl
+    REAL*8, INTENT(OUT) :: flux_limiter
+    REAL*8, PARAMETER :: tol = 1.e-10
+    
+    !IF ((qfs <= tol)) THEN
+    !  flux_limiter = 0.
+    !ELSEIF ((qsh <= tol)) THEN
+    !  flux_limiter = 1.
+    !ELSE
+      flux_limiter = 1./(1.+ABS(qsh)/(c_fl*qfs))
+    !ENDIF
+
+  END SUBROUTINE compute_flux_limiter
+   
+
   ! ******************************
   ! Parallel electric field terms
   ! ******************************

--- a/src/Models/NGammaTiTe/physics.f90
+++ b/src/Models/NGammaTiTe/physics.f90
@@ -1452,14 +1452,13 @@ CONTAINS
     REAL*8, INTENT(IN)  :: qfs, qsh, c_fl
     REAL*8, INTENT(OUT) :: flux_limiter
     REAL*8, PARAMETER :: tol = 1.e-10
+    REAL*8 :: qfs_clamped
     
-    !IF ((qfs <= tol)) THEN
-    !  flux_limiter = 0.
-    !ELSEIF ((qsh <= tol)) THEN
-    !  flux_limiter = 1.
-    !ELSE
-      flux_limiter = 1./(1.+ABS(qsh)/(c_fl*qfs))
-    !ENDIF
+
+    qfs_clamped = MAX(ABS(qfs), tol)
+
+    flux_limiter = 1.0 / (1.0 + ABS(qsh) / (c_fl * qfs_clamped))
+
 
   END SUBROUTINE compute_flux_limiter
    

--- a/src/Models/adimensionalization.f90
+++ b/src/Models/adimensionalization.f90
@@ -170,6 +170,10 @@ SUBROUTINE adimensionalization()
   phys%dfcoef = 2*Tev*t0/(L0**2*B0)
   phys%dexbcoef = phi0/B0*t0/L0**2
 
+  ! flux limiter max temperatures
+  phys%T_fluxlim_maxi = phys%T_fluxlim_maxi/Tev
+  phys%T_fluxlim_maxe = phys%T_fluxlim_maxe/Tev
+
   ! Store reference values
   simpar%refval_mass = mi
   simpar%refval_charge = e

--- a/test/param_diffred.txt
+++ b/test/param_diffred.txt
@@ -253,8 +253,10 @@
     diff_pare           = 20            ! (1.0492e7) parallel diffusion for the electron temperature
     diff_pot            = 4             ! diffusion in the potential equation (only used for analytic tests)
     ! **** Flux limiter coefficients
-    c_fli               = 5.e-1            ! Fraction of the free streaming flux used in the ion flux limiter
-    c_fle               = 2.e-1            ! Fraction of the free streaming flux used in the electron flux limiter
+    c_fli               = 1e5            ! Fraction of the free streaming flux used in the ion flux limiter
+    c_fle               = 2e-1            ! Fraction of the free streaming flux used in the electron flux limiter
+    T_fluxlim_maxi      = 50.              ! Max ion temperature [eV] in old heat flux limiter (limiting T in T^(5/2)), put some large value to turn it off
+    T_fluxlim_maxe      = 50.              ! Max eletron temperature [eV] in old heat flux limiter (limiting T in T^(5/2)), put some large value to turn it off
     ! **** Non isothermal exponential
     epn                 = 2.5           ! exponential of the parallel diffusion for the temperature
     ! ***** Coefficients for the vorticity model

--- a/test/param_diffred.txt
+++ b/test/param_diffred.txt
@@ -10,6 +10,7 @@
                                         ! true = yes (even for magnetic perturbation)
                                         ! false = no
     init                = 1             ! Initialization type: 1-analytical at nodes; 2-L2 projection
+    flux_limiter        = .false.       ! use flux limiter for ion and electron parallel conductive heat fluxes (with provided c_fli,c_fle in physics)
     external_heating    = .false.       ! True will use external from the file provided in INPUT_LST
     impurity_radiation  = .false.        ! to take into account impurity radiaion with concentration provided in PHYS_LST
     import_diffusion_1D = .false.        ! Import or not additional profile of diffuion in 1D as function of rho_pol, supply path to the file
@@ -251,6 +252,9 @@
     diff_pari           = 10            ! (3.1475e5) parallel diffusion for the ions temperature
     diff_pare           = 20            ! (1.0492e7) parallel diffusion for the electron temperature
     diff_pot            = 4             ! diffusion in the potential equation (only used for analytic tests)
+    ! **** Flux limiter coefficients
+    c_fli               = 5.e-1            ! Fraction of the free streaming flux used in the ion flux limiter
+    c_fle               = 2.e-1            ! Fraction of the free streaming flux used in the electron flux limiter
     ! **** Non isothermal exponential
     epn                 = 2.5           ! exponential of the parallel diffusion for the temperature
     ! ***** Coefficients for the vorticity model

--- a/test/param_initial.txt
+++ b/test/param_initial.txt
@@ -10,6 +10,7 @@
                                         ! true = yes (even for magnetic perturbation)
                                         ! false = no
     init                = 1             ! Initialization type: 1-analytical at nodes; 2-L2 projection
+    flux_limiter        = .false.       ! use flux limiter for ion and electron parallel conductive heat fluxes (with provided c_fli,c_fle in physics)
     external_heating    = .false.       ! True will use external from the file provided in INPUT_LST
     impurity_radiation  = .false.        ! to take into account impurity radiaion with concentration provided in PHYS_LST
     import_diffusion_1D = .false.        ! Import or not additional profile of diffuion in 1D as function of rho_pol, supply path to the file
@@ -257,6 +258,9 @@
     diff_pari           = 10            ! (3.1475e5) parallel diffusion for the ions temperature
     diff_pare           = 20            ! (1.0492e7) parallel diffusion for the electron temperature
     diff_pot            = 4             ! diffusion in the potential equation (only used for analytic tests)
+    ! **** Flux limiter coefficients
+    c_fli               = 5.e-1            ! Fraction of the free streaming flux used in the ion flux limiter
+    c_fle               = 2.e-1            ! Fraction of the free streaming flux used in the electron flux limiter
     ! **** Non isothermal exponential
     epn                 = 2.5           ! exponential of the parallel diffusion for the temperature
     ! ***** Coefficients for the vorticity model

--- a/test/param_initial.txt
+++ b/test/param_initial.txt
@@ -259,8 +259,10 @@
     diff_pare           = 20            ! (1.0492e7) parallel diffusion for the electron temperature
     diff_pot            = 4             ! diffusion in the potential equation (only used for analytic tests)
     ! **** Flux limiter coefficients
-    c_fli               = 5.e-1            ! Fraction of the free streaming flux used in the ion flux limiter
-    c_fle               = 2.e-1            ! Fraction of the free streaming flux used in the electron flux limiter
+    c_fli               = 1e5            ! Fraction of the free streaming flux used in the ion flux limiter
+    c_fle               = 2e-1            ! Fraction of the free streaming flux used in the electron flux limiter
+    T_fluxlim_maxi      = 50.              ! Max ion temperature [eV] in old heat flux limiter (limiting T in T^(5/2)), put some large value to turn it off
+    T_fluxlim_maxe      = 50.              ! Max eletron temperature [eV] in old heat flux limiter (limiting T in T^(5/2)), put some large value to turn it off
     ! **** Non isothermal exponential
     epn                 = 2.5           ! exponential of the parallel diffusion for the temperature
     ! ***** Coefficients for the vorticity model

--- a/test/param_reference.txt
+++ b/test/param_reference.txt
@@ -10,6 +10,7 @@
                                         ! true = yes (even for magnetic perturbation)
                                         ! false = no
     init                = 1             ! Initialization type: 1-analytical at nodes; 2-L2 projection
+    flux_limiter        = .false.       ! use flux limiter for ion and electron parallel conductive heat fluxes (with provided c_fli,c_fle in physics)
     external_heating    = .false.       ! True will use external from the file provided in INPUT_LST
     impurity_radiation  = .false.        ! to take into account impurity radiaion with concentration provided in PHYS_LST
     import_diffusion_1D = .false.        ! Import or not additional profile of diffuion in 1D as function of rho_pol, supply path to the file
@@ -257,6 +258,9 @@
     diff_pari           = 10            ! (3.1475e5) parallel diffusion for the ions temperature
     diff_pare           = 20            ! (1.0492e7) parallel diffusion for the electron temperature
     diff_pot            = 4             ! diffusion in the potential equation (only used for analytic tests)
+    ! **** Flux limiter coefficients
+    c_fli               = 5.e-1            ! Fraction of the free streaming flux used in the ion flux limiter
+    c_fle               = 2.e-1            ! Fraction of the free streaming flux used in the electron flux limiter
     ! **** Non isothermal exponential
     epn                 = 2.5           ! exponential of the parallel diffusion for the temperature
     ! ***** Coefficients for the vorticity model

--- a/test/param_reference.txt
+++ b/test/param_reference.txt
@@ -259,8 +259,10 @@
     diff_pare           = 20            ! (1.0492e7) parallel diffusion for the electron temperature
     diff_pot            = 4             ! diffusion in the potential equation (only used for analytic tests)
     ! **** Flux limiter coefficients
-    c_fli               = 5.e-1            ! Fraction of the free streaming flux used in the ion flux limiter
-    c_fle               = 2.e-1            ! Fraction of the free streaming flux used in the electron flux limiter
+    c_fli               = 1e5            ! Fraction of the free streaming flux used in the ion flux limiter
+    c_fle               = 2e-1            ! Fraction of the free streaming flux used in the electron flux limiter
+    T_fluxlim_maxi      = 50.              ! Max ion temperature [eV] in old heat flux limiter (limiting T in T^(5/2)), put some large value to turn it off
+    T_fluxlim_maxe      = 50.              ! Max eletron temperature [eV] in old heat flux limiter (limiting T in T^(5/2)), put some large value to turn it off
     ! **** Non isothermal exponential
     epn                 = 2.5           ! exponential of the parallel diffusion for the temperature
     ! ***** Coefficients for the vorticity model

--- a/test/param_steady.txt
+++ b/test/param_steady.txt
@@ -10,6 +10,7 @@
                                         ! true = yes (even for magnetic perturbation)
                                         ! false = no
     init                = 1             ! Initialization type: 1-analytical at nodes; 2-L2 projection
+    flux_limiter        = .false.       ! use flux limiter for ion and electron parallel conductive heat fluxes (with provided c_fli,c_fle in physics)
     external_heating    = .false.       ! True will use external from the file provided in INPUT_LST
     impurity_radiation  = .false.        ! to take into account impurity radiaion with concentration provided in PHYS_LST
     import_diffusion_1D = .false.        ! Import or not additional profile of diffuion in 1D as function of rho_pol, supply path to the file
@@ -257,6 +258,9 @@
     diff_pari           = 10            ! (3.1475e5) parallel diffusion for the ions temperature
     diff_pare           = 20            ! (1.0492e7) parallel diffusion for the electron temperature
     diff_pot            = 4             ! diffusion in the potential equation (only used for analytic tests)
+    ! **** Flux limiter coefficients
+    c_fli               = 5.e-1            ! Fraction of the free streaming flux used in the ion flux limiter
+    c_fle               = 2.e-1            ! Fraction of the free streaming flux used in the electron flux limiter
     ! **** Non isothermal exponential
     epn                 = 2.5           ! exponential of the parallel diffusion for the temperature
     ! ***** Coefficients for the vorticity model

--- a/test/param_steady.txt
+++ b/test/param_steady.txt
@@ -259,8 +259,10 @@
     diff_pare           = 20            ! (1.0492e7) parallel diffusion for the electron temperature
     diff_pot            = 4             ! diffusion in the potential equation (only used for analytic tests)
     ! **** Flux limiter coefficients
-    c_fli               = 5.e-1            ! Fraction of the free streaming flux used in the ion flux limiter
-    c_fle               = 2.e-1            ! Fraction of the free streaming flux used in the electron flux limiter
+    c_fli               = 1e5            ! Fraction of the free streaming flux used in the ion flux limiter
+    c_fle               = 2e-1            ! Fraction of the free streaming flux used in the electron flux limiter
+    T_fluxlim_maxi      = 50.              ! Max ion temperature [eV] in old heat flux limiter (limiting T in T^(5/2)), put some large value to turn it off
+    T_fluxlim_maxe      = 50.              ! Max eletron temperature [eV] in old heat flux limiter (limiting T in T^(5/2)), put some large value to turn it off
     ! **** Non isothermal exponential
     epn                 = 2.5           ! exponential of the parallel diffusion for the temperature
     ! ***** Coefficients for the vorticity model


### PR DESCRIPTION
Added flux limiter as defined in SOLPS-ITER or SOLEDGE3X. Limiting the conductive flux with free streaming flux. The expression and some details can be found in [paper](https://conferences.iaea.org/event/392/papers/35725/files/13885-Tonello_EX-D2842.pdf) with references there.
Also for old clamping flux limiter added control parameters to easier define max temperature to be taken in calculation of parallel conductivity.
Doesn't work very well, for electrons Cfle can be reduced to 0.2 with no significant change of the solution. For ions the simulation is more unstable, especially at the sharp corners of the mesh. Cfli=2 is fine, going below makes simulation unstable.
T_max increase also makes the simulation unstable. 100 eV is fine, at 200 eV there are crashes