### PR TITLE
Add resumable golden campaign orchestration

### DIFF
--- a/regression_tests/README.md
+++ b/regression_tests/README.md
@@ -94,6 +94,7 @@ ranks, and threads. MPI runs bind each rank to exclusive cores.
 | `warm` | `warm`, `mpi4_omp4` | Fast routine golden check. |
 | `impurity_scalar_baseline` | Impurity off and N, `mpi4_omp4` | Focused compatibility check. |
 | `impurity_mixture` | Impurity off, W, N, and N+W, `mpi4_omp4` | Manual mixture-reference check. |
+| `initialization_smoke` | Disabled-impurity analytical start, `mpi4_omp4` | Execution-only initialization evidence. |
 | `race` | Both one-step workflows, `serial_omp1` vs `serial_omp16` | Routine OpenMP race check. |
 | `cold` | Both full cold workflows, `mpi4_omp4` | Canonical integration check. |
 | `warm_parallelism` | `warm`, all layouts | Periodic layout characterization. |
@@ -191,7 +192,39 @@ regression_tests/regression.sh suite compare \
 
 ### Publish accepted references
 
-After human review, create a new golden bundle:
+For a complete refresh, one command starts or continues the persisted golden
+campaign, stops at each required review gate, and publishes after final checks:
+
+```bash
+regression_tests/regression.sh golden update legacy_case \
+  --settings /private/path/source.env --run-id refresh-01 \
+  --output /private/path/new_golden_bundle --bundle-version 2.5.0
+```
+
+Run the same command again with `--accept STAGE` after reviewing a reported
+gate. `golden status WORKSPACE` shows progress; without `--workspace`, the
+workspace is `MHDG_REGRESSION_RUN_ROOT/golden_campaigns/RUN_ID`. Resumes reject
+changed inputs and never overwrite a workspace, candidate, or output.
+
+The default refresh includes cold matrices, warm and mixture references,
+initialization/race evidence, and final warm/mixture verification. Repeat
+`--only` to select `cold_matrix`, `warm`, or `impurity_mixture`. A cold-matrix
+refresh also updates the canonical warm restart, while `warm` updates the warm
+reference. Updating only warm or only mixture references records a consistency
+warning; select both together to avoid it.
+
+The verified candidate is published atomically as a golden bundle. Campaign
+state, declaration, build metadata, suite summaries, run plans/metadata, and
+comparison reports are registered below `provenance/golden_campaign/`.
+
+The `legacy_case` order was checked against the accepted PR 02 record: clean
+builds at `7ce486f`, its full cold-matrix refresh, the passing disabled
+initialization probe, final mixture verification, and the validated 118-artifact
+`legacy_case_2.4.0-pr02-mixture-golden.1` bundle. Those results defined the
+campaign shape; they were not rerun or treated as resumable campaign state
+because the historical record does not retain every suite path and fingerprint.
+
+For a smaller manually reviewed promotion, create a golden bundle directly:
 
 ```bash
 regression_tests/regression.sh bundle promote \

--- a/regression_tests/README.md
+++ b/regression_tests/README.md
@@ -195,14 +195,16 @@ After human review, create a new golden bundle:
 
 ```bash
 regression_tests/regression.sh bundle promote \
-  /path/to/suite_summary.json \
+  /path/to/cold_matrix/suite_summary.json \
+  /path/to/warm/suite_summary.json \
   --settings /private/path/candidate-settings.env \
   --output /private/path/new_golden_bundle \
   --bundle-version 1.0.0-golden.1
 ```
 
-Promotion validates and copies references and provenance. It never overwrites
-an output, and tests never promote automatically.
+Promotion validates and applies one or more accepted summaries in the given
+order, including their references and provenance. It never overwrites an
+output, and tests never promote automatically.
 
 ## Outputs and provenance
 
@@ -383,6 +385,7 @@ PYTHONPATH=tools python -m unittest discover -s tests -p 'test_*.py'
   meshes. Layout pairs within one race or cold matrix do require exact meshes.
 - Runtime is recorded without a timing threshold.
 - Promotion verifies technical evidence but physical acceptance remains human.
-- One promotion consumes one accepted suite summary.
+- Promotion inputs must all describe accepted results from the configured source
+  bundle.
 
 Run `regression_tests/regression.sh help` for the command synopsis.

--- a/regression_tests/golden_campaigns.json
+++ b/regression_tests/golden_campaigns.json
@@ -11,6 +11,67 @@
           "acceptance_required": true
         },
         {
+          "id": "warm_reference",
+          "kind": "reference",
+          "suite": "warm",
+          "acceptance_required": true,
+          "role_mappings": [
+            {
+              "workflow": "warm",
+              "roles": ["warm_reference"]
+            }
+          ]
+        },
+        {
+          "id": "impurity_restarts",
+          "kind": "reference",
+          "suite": "impurity_references",
+          "acceptance_required": false,
+          "role_mappings": [
+            {
+              "workflow": "warm_impurity_off",
+              "roles": ["warm_impurity_off_restart"]
+            },
+            {
+              "workflow": "warm_impurity_n",
+              "roles": ["warm_impurity_n_restart"]
+            },
+            {
+              "workflow": "warm_impurity_nw",
+              "roles": ["warm_impurity_nw_restart"]
+            }
+          ]
+        },
+        {
+          "id": "impurity_references",
+          "kind": "reference",
+          "suite": "impurity_references",
+          "acceptance_required": true,
+          "role_mappings": [
+            {
+              "workflow": "warm_impurity_off",
+              "roles": [
+                "warm_impurity_off_restart",
+                "warm_impurity_off_reference"
+              ]
+            },
+            {
+              "workflow": "warm_impurity_n",
+              "roles": [
+                "warm_impurity_n_restart",
+                "warm_impurity_n_reference"
+              ]
+            },
+            {
+              "workflow": "warm_impurity_nw",
+              "roles": [
+                "warm_impurity_nw_restart",
+                "warm_impurity_nw_reference"
+              ]
+            }
+          ]
+        },
+        {
           "id": "race_evidence",
           "kind": "suite",
           "suite": "race",

--- a/regression_tests/golden_campaigns.json
+++ b/regression_tests/golden_campaigns.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "campaigns": {
+    "legacy_case": {
+      "case": "legacy_case",
+      "stages": [
+        {
+          "id": "cold_matrix",
+          "kind": "matrix",
+          "suite": "cold_matrix",
+          "acceptance_required": true
+        },
+        {
+          "id": "race_evidence",
+          "kind": "suite",
+          "suite": "race",
+          "acceptance_required": false
+        }
+      ]
+    }
+  }
+}

--- a/regression_tests/golden_campaigns.json
+++ b/regression_tests/golden_campaigns.json
@@ -3,17 +3,22 @@
   "campaigns": {
     "legacy_case": {
       "case": "legacy_case",
+      "update_together": [
+        ["warm", "impurity_mixture"]
+      ],
       "stages": [
         {
           "id": "cold_matrix",
           "kind": "matrix",
           "suite": "cold_matrix",
+          "component": "cold_matrix",
           "acceptance_required": true
         },
         {
           "id": "warm_reference",
           "kind": "reference",
           "suite": "warm",
+          "component": "warm",
           "acceptance_required": true,
           "role_mappings": [
             {
@@ -26,6 +31,7 @@
           "id": "impurity_restarts",
           "kind": "reference",
           "suite": "impurity_references",
+          "component": "impurity_mixture",
           "acceptance_required": false,
           "role_mappings": [
             {
@@ -46,6 +52,7 @@
           "id": "impurity_references",
           "kind": "reference",
           "suite": "impurity_references",
+          "component": "impurity_mixture",
           "acceptance_required": true,
           "role_mappings": [
             {
@@ -72,9 +79,27 @@
           ]
         },
         {
+          "id": "initialization_smoke",
+          "kind": "suite",
+          "suite": "initialization_smoke",
+          "acceptance_required": false
+        },
+        {
           "id": "race_evidence",
           "kind": "suite",
           "suite": "race",
+          "acceptance_required": false
+        },
+        {
+          "id": "verify_warm",
+          "kind": "verification",
+          "suite": "warm",
+          "acceptance_required": false
+        },
+        {
+          "id": "verify_impurity_mixture",
+          "kind": "verification",
+          "suite": "impurity_mixture",
           "acceptance_required": false
         }
       ]

--- a/regression_tests/regression.sh
+++ b/regression_tests/regression.sh
@@ -19,6 +19,8 @@ Usage:
   regression_tests/regression.sh suite run SUITE --settings FILE [--run-only] [--resume]
   regression_tests/regression.sh suite compare SUITE_SUMMARY
   regression_tests/regression.sh suite check [SUITE] [--settings FILE] [--build]
+  regression_tests/regression.sh golden update CASE --settings FILE --run-id ID --output DIR --bundle-version VERSION
+  regression_tests/regression.sh golden status WORKSPACE
 
 Commands:
   bundle create    Create a validated candidate bundle from prepared files.
@@ -31,6 +33,8 @@ Commands:
   suite run        Execute every workflow-layout cell in a tracked suite.
   suite compare    Recompare saved suite results without running the solver.
   suite check      Run a suite against a required golden bundle (default: warm).
+  golden update    Start or continue an ordered golden-reference update.
+  golden status    Show persisted golden-update state.
 
 Suites: warm, impurity_scalar_baseline, impurity_mixture, race, cold,
         warm_parallelism, race_matrix, cold_matrix.
@@ -123,6 +127,21 @@ run_golden_suite() {
     "$@"
 }
 
+run_golden_command() {
+  local action=${1:-}
+  case "$action" in
+    update|status)
+      run_python golden_update.py "$@"
+      ;;
+    help|-h|--help)
+      run_python golden_update.py --help
+      ;;
+    *)
+      fail "expected 'golden update' or 'golden status'"
+      ;;
+  esac
+}
+
 if (($# == 0)); then
   usage
   exit 0
@@ -160,6 +179,9 @@ case "$command" in
     ;;
   suite)
     run_suite_command "$@"
+    ;;
+  golden)
+    run_golden_command "$@"
     ;;
   *)
     fail "unknown command: $command"

--- a/regression_tests/regression.sh
+++ b/regression_tests/regression.sh
@@ -19,7 +19,7 @@ Usage:
   regression_tests/regression.sh suite run SUITE --settings FILE [--run-only] [--resume]
   regression_tests/regression.sh suite compare SUITE_SUMMARY
   regression_tests/regression.sh suite check [SUITE] [--settings FILE] [--build]
-  regression_tests/regression.sh golden update CASE --settings FILE --run-id ID --output DIR --bundle-version VERSION
+  regression_tests/regression.sh golden update CASE --settings FILE --run-id ID --output DIR --bundle-version VERSION [--only COMPONENT]
   regression_tests/regression.sh golden status WORKSPACE
 
 Commands:
@@ -36,7 +36,8 @@ Commands:
   golden update    Start or continue an ordered golden-reference update.
   golden status    Show persisted golden-update state.
 
-Suites: warm, impurity_scalar_baseline, impurity_mixture, impurity_references, race, cold,
+Suites: warm, impurity_scalar_baseline, impurity_mixture, impurity_references,
+        initialization_smoke, race, cold,
         warm_parallelism, race_matrix, cold_matrix.
 EOF
 }

--- a/regression_tests/regression.sh
+++ b/regression_tests/regression.sh
@@ -36,7 +36,7 @@ Commands:
   golden update    Start or continue an ordered golden-reference update.
   golden status    Show persisted golden-update state.
 
-Suites: warm, impurity_scalar_baseline, impurity_mixture, race, cold,
+Suites: warm, impurity_scalar_baseline, impurity_mixture, impurity_references, race, cold,
         warm_parallelism, race_matrix, cold_matrix.
 EOF
 }

--- a/regression_tests/regression.sh
+++ b/regression_tests/regression.sh
@@ -11,7 +11,7 @@ Usage:
   regression_tests/regression.sh help
   regression_tests/regression.sh bundle create --case CASE --source DIR --output DIR
   regression_tests/regression.sh bundle validate --settings FILE
-  regression_tests/regression.sh bundle promote SUITE_SUMMARY --settings FILE --output DIR --bundle-version VERSION
+  regression_tests/regression.sh bundle promote SUITE_SUMMARY [SUITE_SUMMARY ...] --settings FILE --output DIR --bundle-version VERSION
   regression_tests/regression.sh build --settings FILE [--jobs N]
   regression_tests/regression.sh prepare CASE WORKFLOW --layout LAYOUT --settings FILE
   regression_tests/regression.sh run CASE WORKFLOW [WORKFLOW ...] --layout LAYOUT --settings FILE

--- a/regression_tests/schemas/golden-campaigns.schema.json
+++ b/regression_tests/schemas/golden-campaigns.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/wave46/MHDG/develop/regression_tests/schemas/golden-campaigns.schema.json",
+  "title": "MHDG golden campaigns",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "campaigns"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "campaigns": {
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": {"$ref": "#/$defs/identifier"},
+      "additionalProperties": {"$ref": "#/$defs/campaign"}
+    }
+  },
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*$"
+    },
+    "campaign": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["case", "stages"],
+      "properties": {
+        "case": {"$ref": "#/$defs/identifier"},
+        "stages": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/stage"}
+        }
+      }
+    },
+    "stage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind", "suite", "acceptance_required"],
+      "properties": {
+        "id": {"$ref": "#/$defs/identifier"},
+        "kind": {"enum": ["matrix", "suite"]},
+        "suite": {"$ref": "#/$defs/identifier"},
+        "acceptance_required": {"type": "boolean"}
+      }
+    }
+  }
+}

--- a/regression_tests/schemas/golden-campaigns.schema.json
+++ b/regression_tests/schemas/golden-campaigns.schema.json
@@ -25,6 +25,15 @@
       "required": ["case", "stages"],
       "properties": {
         "case": {"$ref": "#/$defs/identifier"},
+        "update_together": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "minItems": 2,
+            "uniqueItems": true,
+            "items": {"$ref": "#/$defs/identifier"}
+          }
+        },
         "stages": {
           "type": "array",
           "minItems": 1,
@@ -38,8 +47,9 @@
       "required": ["id", "kind", "suite", "acceptance_required"],
       "properties": {
         "id": {"$ref": "#/$defs/identifier"},
-        "kind": {"enum": ["matrix", "reference", "suite"]},
+        "kind": {"enum": ["matrix", "reference", "suite", "verification"]},
         "suite": {"$ref": "#/$defs/identifier"},
+        "component": {"$ref": "#/$defs/identifier"},
         "acceptance_required": {"type": "boolean"},
         "role_mappings": {
           "type": "array",

--- a/regression_tests/schemas/golden-campaigns.schema.json
+++ b/regression_tests/schemas/golden-campaigns.schema.json
@@ -38,9 +38,28 @@
       "required": ["id", "kind", "suite", "acceptance_required"],
       "properties": {
         "id": {"$ref": "#/$defs/identifier"},
-        "kind": {"enum": ["matrix", "suite"]},
+        "kind": {"enum": ["matrix", "reference", "suite"]},
         "suite": {"$ref": "#/$defs/identifier"},
-        "acceptance_required": {"type": "boolean"}
+        "acceptance_required": {"type": "boolean"},
+        "role_mappings": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/role_mapping"}
+        }
+      }
+    },
+    "role_mapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workflow", "roles"],
+      "properties": {
+        "workflow": {"$ref": "#/$defs/identifier"},
+        "roles": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/identifier"}
+        }
       }
     }
   }

--- a/regression_tests/suites.json
+++ b/regression_tests/suites.json
@@ -24,6 +24,16 @@
       ],
       "layouts": ["mpi4_omp4"]
     },
+    "impurity_references": {
+      "description": "Off, nitrogen, and mixed-impurity reference producers",
+      "case": "legacy_case",
+      "workflows": [
+        "warm_impurity_off",
+        "warm_impurity_n",
+        "warm_impurity_nw"
+      ],
+      "layouts": ["mpi4_omp4"]
+    },
     "warm_parallelism": {
       "description": "Warm restart across serial, MPI, and OpenMP layouts",
       "case": "legacy_case",

--- a/regression_tests/suites.json
+++ b/regression_tests/suites.json
@@ -34,6 +34,13 @@
       ],
       "layouts": ["mpi4_omp4"]
     },
+    "initialization_smoke": {
+      "description": "One-step analytical initialization without reference comparison",
+      "case": "legacy_case",
+      "workflows": ["cold_step_impurity_off"],
+      "layouts": ["mpi4_omp4"],
+      "reference_comparisons": false
+    },
     "warm_parallelism": {
       "description": "Warm restart across serial, MPI, and OpenMP layouts",
       "case": "legacy_case",

--- a/regression_tests/tests/test_golden_update.py
+++ b/regression_tests/tests/test_golden_update.py
@@ -49,11 +49,11 @@ class GoldenUpdateTests(unittest.TestCase):
         )
         self.promote_bundle = self._patch(
             "promote_bundle",
-            side_effect=lambda *args, **kwargs: args[2].mkdir(parents=True),
+            side_effect=lambda *args, **kwargs: self._create_candidate(args[2]),
         )
         self.promote_mapped_bundle = self._patch(
             "promote_mapped_bundle",
-            side_effect=lambda *args, **kwargs: args[3].mkdir(parents=True),
+            side_effect=lambda *args, **kwargs: self._create_candidate(args[3]),
         )
 
     def test_update_stops_at_gate_then_continues_in_order(self) -> None:
@@ -94,7 +94,10 @@ class GoldenUpdateTests(unittest.TestCase):
                 "warm",
                 "impurity_references",
                 "impurity_references",
+                "initialization_smoke",
                 "race",
+                "warm",
+                "impurity_mixture",
             ],
         )
         self.assertEqual(self.promote_bundle.call_count, 1)
@@ -102,7 +105,7 @@ class GoldenUpdateTests(unittest.TestCase):
         calls = self.run_suite.call_args_list
         self.assertEqual(
             [call.args[7] for call in calls],
-            ["golden", "candidate", "candidate", "candidate", "candidate"],
+            ["golden", *("candidate" for _ in range(7))],
         )
         self.assertEqual(
             [Path(call.args[0]).name for call in calls[1:]],
@@ -111,15 +114,48 @@ class GoldenUpdateTests(unittest.TestCase):
                 "warm_reference.env",
                 "impurity_restarts.env",
                 "impurity_references.env",
+                "impurity_references.env",
+                "impurity_references.env",
+                "impurity_references.env",
             ],
+        )
+        self.assertEqual(
+            self.promote_bundle.call_args.kwargs["matrix_warm_roles"],
+            ("warm_restart",),
         )
         state = self._state()
         self.assertEqual(state["status"], "stages_completed")
+        self.assertEqual(
+            state["verification_candidate"]["root"],
+            state["active_bundle"],
+        )
         self.assertIsNotNone(state["stages"][0].get("accepted_utc"))
         self.assertFalse(self.output.exists())
         completed = run_command("golden", "status", str(self.workspace))
         self.assertEqual(completed.returncode, 0, completed.stderr)
         self.assertIn("cold_matrix: completed", completed.stdout)
+
+    def test_partial_warm_update_warns_and_preserves_other_components(self) -> None:
+        self.assertEqual(self._run("--only", "warm"), 0)
+        state = self._state()
+        self.assertEqual(state["stages"][0]["status"], "skipped")
+        self.assertEqual(state["stages"][1]["status"], "awaiting_acceptance")
+        self.assertEqual(len(state["warnings"]), 1)
+
+        self.assertEqual(
+            self._run("--only", "warm", "--accept", "warm_reference"),
+            0,
+        )
+        self.assertEqual(
+            [call.args[1] for call in self.run_suite.call_args_list],
+            ["warm", "warm", "impurity_mixture"],
+        )
+        state = self._state()
+        self.assertEqual(state["status"], "stages_completed")
+        self.assertEqual(state["stages"][2]["status"], "skipped")
+        self.assertEqual(state["stages"][3]["status"], "skipped")
+        self.assertEqual(self.promote_bundle.call_count, 0)
+        self.assertEqual(self.promote_mapped_bundle.call_count, 1)
 
     def test_interrupted_suite_uses_existing_resume(self) -> None:
         calls = []
@@ -172,6 +208,10 @@ class GoldenUpdateTests(unittest.TestCase):
         path = self.root / f"{args[1]}-summary.json"
         path.write_text("{}\n", encoding="utf-8")
         return path, {"status": "passed"}
+
+    def _create_candidate(self, path: Path) -> None:
+        path.mkdir(parents=True)
+        (path / "manifest.json").write_text("{}\n", encoding="utf-8")
 
     def _patch(self, name: str, **kwargs):
         patcher = patch.object(golden_update, name, **kwargs)

--- a/regression_tests/tests/test_golden_update.py
+++ b/regression_tests/tests/test_golden_update.py
@@ -47,6 +47,14 @@ class GoldenUpdateTests(unittest.TestCase):
             "verify_suite",
             return_value=(old_report, {"status": "failed"}),
         )
+        self.promote_bundle = self._patch(
+            "promote_bundle",
+            side_effect=lambda *args, **kwargs: args[2].mkdir(parents=True),
+        )
+        self.promote_mapped_bundle = self._patch(
+            "promote_mapped_bundle",
+            side_effect=lambda *args, **kwargs: args[3].mkdir(parents=True),
+        )
 
     def test_update_stops_at_gate_then_continues_in_order(self) -> None:
         suites = []
@@ -63,10 +71,47 @@ class GoldenUpdateTests(unittest.TestCase):
         self.assertEqual(state["status"], "awaiting_acceptance")
         self.assertEqual(state["stages"][0]["status"], "awaiting_acceptance")
         self.assertEqual(self._run("--accept", "cold_matrix"), 0)
+        self.assertEqual(suites[-1][0], "warm")
+        self.assertEqual(
+            self._state()["stages"][1]["status"],
+            "awaiting_acceptance",
+        )
+        self.assertEqual(self._run("--accept", "warm_reference"), 0)
+        self.assertEqual(
+            [suite for suite, _, _ in suites[-2:]],
+            ["impurity_references", "impurity_references"],
+        )
+        self.assertEqual(
+            self._state()["stages"][3]["status"],
+            "awaiting_acceptance",
+        )
+        self.assertEqual(self._run("--accept", "impurity_references"), 0)
 
         self.assertEqual(
-            suites,
-            [("cold_matrix", False, False), ("race", True, False)],
+            [suite for suite, _, _ in suites],
+            [
+                "cold_matrix",
+                "warm",
+                "impurity_references",
+                "impurity_references",
+                "race",
+            ],
+        )
+        self.assertEqual(self.promote_bundle.call_count, 1)
+        self.assertEqual(self.promote_mapped_bundle.call_count, 3)
+        calls = self.run_suite.call_args_list
+        self.assertEqual(
+            [call.args[7] for call in calls],
+            ["golden", "candidate", "candidate", "candidate", "candidate"],
+        )
+        self.assertEqual(
+            [Path(call.args[0]).name for call in calls[1:]],
+            [
+                "cold_matrix.env",
+                "warm_reference.env",
+                "impurity_restarts.env",
+                "impurity_references.env",
+            ],
         )
         state = self._state()
         self.assertEqual(state["status"], "stages_completed")

--- a/regression_tests/tests/test_golden_update.py
+++ b/regression_tests/tests/test_golden_update.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+REGRESSION_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REGRESSION_ROOT / "tools"))
+
+import golden_update  # noqa: E402
+from support.errors import BundleError  # noqa: E402
+from tests.fixtures.harness import create_harness, run_command  # noqa: E402
+
+
+class GoldenUpdateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.root = Path(self.temporary_directory.name)
+        harness_root = self.root / "harness"
+        harness_root.mkdir()
+        self.harness = create_harness(harness_root)
+        self.harness.set_bundle_class("golden")
+        self.workspace = self.root / "campaign"
+        self.output = self.root / "new-golden"
+        self.build = SimpleNamespace(
+            path=self.root / "build",
+            settings_path=self.harness.settings,
+            metadata_path=self.root / "build/metadata.json",
+        )
+        self.build_solver = self._patch("build_solver", return_value=self.build)
+        self.run_suite = self._patch("run_suite", side_effect=self._passing_suite)
+        self.compare_pairs = self._patch(
+            "compare_layout_pairs",
+            return_value=[{"status": "passed"}],
+        )
+        old_report = self.root / "old-golden.json"
+        old_report.write_text("{}\n", encoding="utf-8")
+        self.verify_suite = self._patch(
+            "verify_suite",
+            return_value=(old_report, {"status": "failed"}),
+        )
+
+    def test_update_stops_at_gate_then_continues_in_order(self) -> None:
+        suites = []
+
+        def run_suite(*args, **kwargs):
+            suite_id = args[1]
+            suites.append((suite_id, kwargs["compare"], kwargs["resume"]))
+            return self._passing_suite(*args, **kwargs)
+
+        self.run_suite.side_effect = run_suite
+        self.assertEqual(self._run(), 0)
+        self.assertEqual(suites, [("cold_matrix", False, False)])
+        state = self._state()
+        self.assertEqual(state["status"], "awaiting_acceptance")
+        self.assertEqual(state["stages"][0]["status"], "awaiting_acceptance")
+        self.assertEqual(self._run("--accept", "cold_matrix"), 0)
+
+        self.assertEqual(
+            suites,
+            [("cold_matrix", False, False), ("race", True, False)],
+        )
+        state = self._state()
+        self.assertEqual(state["status"], "stages_completed")
+        self.assertIsNotNone(state["stages"][0].get("accepted_utc"))
+        self.assertFalse(self.output.exists())
+        completed = run_command("golden", "status", str(self.workspace))
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("cold_matrix: completed", completed.stdout)
+
+    def test_interrupted_suite_uses_existing_resume(self) -> None:
+        calls = []
+
+        def run_suite(*args, **kwargs):
+            calls.append(kwargs["resume"])
+            if len(calls) == 1:
+                raise BundleError("synthetic interruption")
+            return self._passing_suite(*args, **kwargs)
+
+        self.run_suite.side_effect = run_suite
+        with redirect_stderr(StringIO()):
+            self.assertEqual(self._run(), 1)
+            self.assertEqual(self._run(), 0)
+
+        self.assertEqual(calls, [False, True])
+        self.assertEqual(self._state()["stages"][0]["status"], "awaiting_acceptance")
+
+    def test_changed_source_settings_reject_resume(self) -> None:
+        self.assertEqual(self._run(), 0)
+        with self.harness.settings.open("a", encoding="utf-8") as stream:
+            stream.write("# changed\n")
+        with redirect_stderr(StringIO()) as errors:
+            self.assertEqual(self._run(), 1)
+
+        self.assertIn("campaign inputs changed", errors.getvalue())
+
+    def _arguments(self, *extra: str) -> list[str]:
+        return [
+            "update",
+            "legacy_case",
+            "--settings",
+            str(self.harness.settings),
+            "--run-id",
+            "golden-test",
+            "--workspace",
+            str(self.workspace),
+            "--output",
+            str(self.output),
+            "--bundle-version",
+            "golden-test-1",
+            *extra,
+        ]
+
+    def _run(self, *extra: str) -> int:
+        with redirect_stdout(StringIO()):
+            return golden_update.main(self._arguments(*extra))
+
+    def _passing_suite(self, *args, **kwargs):
+        path = self.root / f"{args[1]}-summary.json"
+        path.write_text("{}\n", encoding="utf-8")
+        return path, {"status": "passed"}
+
+    def _patch(self, name: str, **kwargs):
+        patcher = patch.object(golden_update, name, **kwargs)
+        self.addCleanup(patcher.stop)
+        return patcher.start()
+
+    def _state(self) -> dict:
+        return json.loads(
+            (self.workspace / golden_update.STATE_FILE).read_text(encoding="utf-8")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/regression_tests/tests/test_golden_update.py
+++ b/regression_tests/tests/test_golden_update.py
@@ -35,6 +35,8 @@ class GoldenUpdateTests(unittest.TestCase):
             settings_path=self.harness.settings,
             metadata_path=self.root / "build/metadata.json",
         )
+        self.build.metadata_path.parent.mkdir()
+        self.build.metadata_path.write_text("{}\n", encoding="utf-8")
         self.build_solver = self._patch("build_solver", return_value=self.build)
         self.run_suite = self._patch("run_suite", side_effect=self._passing_suite)
         self.compare_pairs = self._patch(
@@ -55,6 +57,11 @@ class GoldenUpdateTests(unittest.TestCase):
             "promote_mapped_bundle",
             side_effect=lambda *args, **kwargs: self._create_candidate(args[3]),
         )
+        self.publish_campaign_bundle = self._patch(
+            "publish_campaign_bundle",
+            side_effect=lambda *args, **kwargs: self._create_candidate(args[1]),
+        )
+        self.validate_published = self._patch("_validate_published")
 
     def test_update_stops_at_gate_then_continues_in_order(self) -> None:
         suites = []
@@ -124,13 +131,24 @@ class GoldenUpdateTests(unittest.TestCase):
             ("warm_restart",),
         )
         state = self._state()
-        self.assertEqual(state["status"], "stages_completed")
+        self.assertEqual(state["status"], "published")
         self.assertEqual(
             state["verification_candidate"]["root"],
             state["active_bundle"],
         )
         self.assertIsNotNone(state["stages"][0].get("accepted_utc"))
-        self.assertFalse(self.output.exists())
+        self.assertTrue(self.output.exists())
+        self.assertEqual(self.publish_campaign_bundle.call_count, 1)
+        published_files = dict(self.publish_campaign_bundle.call_args.args[4])
+        self.assertIn("campaign.json", published_files)
+        self.assertIn("build/build_metadata.json", published_files)
+        self.assertIn(
+            "stages/verify_impurity_mixture/suite_summary.json",
+            published_files,
+        )
+        self.assertEqual(self._run(), 0)
+        self.assertEqual(self.publish_campaign_bundle.call_count, 1)
+        self.validate_published.assert_called_once()
         completed = run_command("golden", "status", str(self.workspace))
         self.assertEqual(completed.returncode, 0, completed.stderr)
         self.assertIn("cold_matrix: completed", completed.stdout)
@@ -151,7 +169,7 @@ class GoldenUpdateTests(unittest.TestCase):
             ["warm", "warm", "impurity_mixture"],
         )
         state = self._state()
-        self.assertEqual(state["status"], "stages_completed")
+        self.assertEqual(state["status"], "published")
         self.assertEqual(state["stages"][2]["status"], "skipped")
         self.assertEqual(state["stages"][3]["status"], "skipped")
         self.assertEqual(self.promote_bundle.call_count, 0)
@@ -206,8 +224,17 @@ class GoldenUpdateTests(unittest.TestCase):
 
     def _passing_suite(self, *args, **kwargs):
         path = self.root / f"{args[1]}-summary.json"
-        path.write_text("{}\n", encoding="utf-8")
-        return path, {"status": "passed"}
+        summary = {
+            "status": "passed",
+            "execution_inputs": {
+                "build_manifest": golden_update._file_record(
+                    self.build.metadata_path,
+                )
+            },
+            "results": [],
+        }
+        path.write_text(json.dumps(summary) + "\n", encoding="utf-8")
+        return path, summary
 
     def _create_candidate(self, path: Path) -> None:
         path.mkdir(parents=True)

--- a/regression_tests/tests/test_reference_publication.py
+++ b/regression_tests/tests/test_reference_publication.py
@@ -12,7 +12,7 @@ sys.path.insert(0, str(REGRESSION_ROOT / "tools"))
 
 from bundle.cases import load_case_definition  # noqa: E402
 from bundle.creation import create_bundle  # noqa: E402
-from bundle.promotion import promote_bundle  # noqa: E402
+from bundle.promotion import promote_bundle, promote_mapped_bundle  # noqa: E402
 from bundle.validation import validate_bundle_root  # noqa: E402
 from support.errors import BundleError  # noqa: E402
 from support.files import file_identity  # noqa: E402
@@ -145,6 +145,47 @@ class ReferencePublicationTests(unittest.TestCase):
         self.assertTrue(
             (self.output / "provenance/golden_reference/suite_summary.json").is_file()
         )
+
+    def test_mapped_publication_replaces_declared_workflow_roles(self) -> None:
+        summary = self._write_mapped_summary(
+            "warm_impurity_off",
+            "warm_impurity_n",
+        )
+
+        promote_mapped_bundle(
+            self.settings,
+            summary,
+            [
+                {
+                    "workflow": "warm_impurity_off",
+                    "roles": [
+                        "warm_impurity_off_restart",
+                        "warm_impurity_off_reference",
+                    ],
+                },
+                {
+                    "workflow": "warm_impurity_n",
+                    "roles": ["warm_impurity_n_reference"],
+                },
+            ],
+            self.output,
+            "mapped-candidate-1",
+            REGRESSION_ROOT / "cases",
+        )
+
+        validate_bundle_root(self.output, REGRESSION_ROOT / "cases")
+        manifest = _load_json(self.output / "manifest.json")
+        self.assertEqual(manifest["bundle_class"], "candidate")
+        for role, expected in (
+            ("warm_impurity_off_restart", "warm_impurity_off\n"),
+            ("warm_impurity_off_reference", "warm_impurity_off\n"),
+            ("warm_impurity_n_reference", "warm_impurity_n\n"),
+        ):
+            artifact = manifest["artifacts"][manifest["roles"][role]]
+            self.assertEqual(
+                (self.output / artifact["path"]).read_text(encoding="utf-8"),
+                expected,
+            )
 
     def test_failed_suite_is_not_publishable(self) -> None:
         summary = _load_json(self.summary)
@@ -298,6 +339,61 @@ class ReferencePublicationTests(unittest.TestCase):
                         "run_directory": str(run),
                     }
                 ],
+            },
+        )
+        return path
+
+    def _write_mapped_summary(self, *workflow_ids: str) -> Path:
+        manifest = _load_json(self.candidate / "manifest.json")
+        results = []
+        for workflow_id in workflow_ids:
+            run = self.root / f"{workflow_id}_run"
+            (run / "outputs").mkdir(parents=True)
+            solution = run / "outputs/result.h5"
+            solution.write_text(f"{workflow_id}\n", encoding="utf-8")
+            _write_json(
+                run / "run_plan.json",
+                {
+                    "case_id": "legacy_case",
+                    "workflow_id": workflow_id,
+                    "layout_id": "mpi4_omp4",
+                    "bundle": {
+                        "root": str(self.candidate),
+                        "bundle_id": manifest["bundle_id"],
+                        "bundle_version": manifest["bundle_version"],
+                    },
+                },
+            )
+            _write_json(
+                run / "run_metadata.json",
+                {
+                    "status": "completed",
+                    "hdf5_outputs": ["outputs/result.h5"],
+                },
+            )
+            results.append(
+                {
+                    "workflow_id": workflow_id,
+                    "layout_id": "mpi4_omp4",
+                    "status": "passed",
+                    "run_status": "completed",
+                    "comparison_status": "not_run",
+                    "run_directory": str(run),
+                }
+            )
+        path = self.root / "mapped_summary.json"
+        _write_json(
+            path,
+            {
+                "schema_version": 2,
+                "status": "passed",
+                "suite_id": "impurity_references",
+                "run_id": "mapped-test",
+                "case_id": "legacy_case",
+                "workflow_ids": list(workflow_ids),
+                "layout_ids": ["mpi4_omp4"],
+                "comparison_mode": "deferred",
+                "results": results,
             },
         )
         return path

--- a/regression_tests/tests/test_reference_publication.py
+++ b/regression_tests/tests/test_reference_publication.py
@@ -110,6 +110,42 @@ class ReferencePublicationTests(unittest.TestCase):
                 "continuation_05\n",
             )
 
+    def test_publication_applies_multiple_summaries_in_order(self) -> None:
+        matrix_summary = self._write_matrix_summary()
+
+        completed = run_command(
+            "bundle",
+            "promote",
+            str(matrix_summary),
+            str(self.summary),
+            "--settings",
+            str(self.settings),
+            "--output",
+            str(self.output),
+            "--bundle-version",
+            "composed-golden-1",
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        validate_bundle_root(self.output, REGRESSION_ROOT / "cases")
+        manifest = _load_json(self.output / "manifest.json")
+        warm_reference = manifest["artifacts"][manifest["roles"]["warm_reference"]]
+        warm_restart = manifest["artifacts"][manifest["roles"]["warm_restart"]]
+        self.assertEqual(
+            (self.output / warm_reference["path"]).read_text(encoding="utf-8"),
+            "new golden\n",
+        )
+        self.assertEqual(
+            (self.output / warm_restart["path"]).read_text(encoding="utf-8"),
+            "continuation_05\n",
+        )
+        self.assertTrue(
+            (self.output / "provenance/golden_matrix/suite_summary.json").is_file()
+        )
+        self.assertTrue(
+            (self.output / "provenance/golden_reference/suite_summary.json").is_file()
+        )
+
     def test_failed_suite_is_not_publishable(self) -> None:
         summary = _load_json(self.summary)
         summary["status"] = "failed"

--- a/regression_tests/tests/test_reference_publication.py
+++ b/regression_tests/tests/test_reference_publication.py
@@ -12,7 +12,11 @@ sys.path.insert(0, str(REGRESSION_ROOT / "tools"))
 
 from bundle.cases import load_case_definition  # noqa: E402
 from bundle.creation import create_bundle  # noqa: E402
-from bundle.promotion import promote_bundle, promote_mapped_bundle  # noqa: E402
+from bundle.promotion import (  # noqa: E402
+    promote_bundle,
+    promote_mapped_bundle,
+    publish_campaign_bundle,
+)
 from bundle.validation import validate_bundle_root  # noqa: E402
 from support.errors import BundleError  # noqa: E402
 from support.files import file_identity  # noqa: E402
@@ -145,6 +149,27 @@ class ReferencePublicationTests(unittest.TestCase):
         self.assertTrue(
             (self.output / "provenance/golden_reference/suite_summary.json").is_file()
         )
+
+    def test_campaign_publication_registers_compact_provenance(self) -> None:
+        campaign = self.root / "campaign.json"
+        declaration = self.root / "declaration.json"
+        _write_json(campaign, {"status": "publishing"})
+        _write_json(declaration, {"stages": []})
+
+        publish_campaign_bundle(
+            self.candidate,
+            self.output,
+            "campaign-golden-1",
+            REGRESSION_ROOT / "cases",
+            [("campaign.json", campaign), ("declaration.json", declaration)],
+        )
+
+        validate_bundle_root(self.output, REGRESSION_ROOT / "cases")
+        manifest = _load_json(self.output / "manifest.json")
+        paths = {artifact["path"] for artifact in manifest["artifacts"].values()}
+        self.assertIn("provenance/golden_campaign/campaign.json", paths)
+        self.assertIn("provenance/golden_campaign/declaration.json", paths)
+        self.assertEqual(manifest["bundle_class"], "golden")
 
     def test_mapped_publication_replaces_declared_workflow_roles(self) -> None:
         summary = self._write_mapped_summary(

--- a/regression_tests/tests/test_suites.py
+++ b/regression_tests/tests/test_suites.py
@@ -195,6 +195,14 @@ class SuiteWorkflowTests(unittest.TestCase):
             _comparison_mode(True, False, False),
             "deferred_layout_pairs",
         )
+        smoke = load_suite_definition(
+            "initialization_smoke",
+            REGRESSION_ROOT / "suites.json",
+            REGRESSION_ROOT / "layouts.json",
+            REGRESSION_ROOT / "cases",
+        )
+        self.assertFalse(smoke["reference_comparisons"])
+        self.assertEqual(_comparison_mode(False, False, True), "execution_only")
 
     def test_generated_adaptive_mesh_comparison_is_byte_exact(self) -> None:
         reference = self.root / "reference/stages/01_single_step/res/temp.msh"

--- a/regression_tests/tests/test_suites.py
+++ b/regression_tests/tests/test_suites.py
@@ -322,6 +322,16 @@ class SuiteWorkflowTests(unittest.TestCase):
         self.assertEqual(len(report["comparisons"]), 1)
         self.assertEqual(report["status"], "passed")
 
+        compare_pairs.reset_mock()
+        _, references_only = verify_suite(
+            source,
+            REGRESSION_ROOT / "cases",
+            REGRESSION_ROOT / "tolerances.json",
+            include_layout_pairs=False,
+        )
+        compare_pairs.assert_not_called()
+        self.assertNotIn("comparisons", references_only)
+
     def _run_suite(self, suite: str, run_id: str, *arguments: str):
         return run_command(
             "suite",

--- a/regression_tests/tools/bundle/promotion.py
+++ b/regression_tests/tools/bundle/promotion.py
@@ -44,6 +44,7 @@ def promote_bundle(
     case_directory: Path,
     *,
     bundle_class: str = "golden",
+    matrix_warm_roles: tuple[str, ...] = ("warm_restart", "warm_reference"),
 ) -> ValidationSummary:
     """Copy a source bundle and install accepted reference results in order."""
     source_bundle = bundle_root_from_settings(read_settings(settings_path))
@@ -76,6 +77,7 @@ def promote_bundle(
         bundle_version,
         bundle_class,
         case_directory,
+        matrix_warm_roles,
     )
 
 
@@ -111,6 +113,7 @@ def promote_mapped_bundle(
         bundle_version,
         bundle_class,
         case_directory,
+        ("warm_restart", "warm_reference"),
     )
 
 
@@ -124,6 +127,7 @@ def _publish_bundle(
     bundle_version: str,
     bundle_class: str,
     case_directory: Path,
+    matrix_warm_roles: tuple[str, ...],
 ) -> ValidationSummary:
     if not bundle_version.strip():
         raise BundleError("bundle version must not be empty")
@@ -154,6 +158,7 @@ def _publish_bundle(
                     accepted,
                     case,
                     source_manifest,
+                    matrix_warm_roles,
                 )
             manifest["bundle_version"] = bundle_version
             manifest["bundle_class"] = bundle_class
@@ -196,6 +201,7 @@ def _install_references(
     accepted: AcceptedReferences,
     case: dict[str, Any],
     source_manifest: dict[str, Any],
+    matrix_warm_roles: tuple[str, ...],
 ) -> None:
     if isinstance(accepted, CanonicalReference):
         install_canonical_reference(
@@ -219,4 +225,5 @@ def _install_references(
         accepted,
         case,
         source_manifest,
+        matrix_warm_roles,
     )

--- a/regression_tests/tools/bundle/promotion.py
+++ b/regression_tests/tools/bundle/promotion.py
@@ -8,6 +8,7 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
+from bundle.artifacts import register_artifact
 from bundle.cases import load_case_definition
 from bundle.models import ValidationSummary
 from bundle.settings import bundle_root_from_settings, read_settings
@@ -34,6 +35,32 @@ from support.time import utc_now
 
 
 AcceptedReferences = CanonicalReference | MappedReferences | list[MatrixRun]
+
+
+def publish_campaign_bundle(
+    source_bundle: Path,
+    output: Path,
+    bundle_version: str,
+    case_directory: Path,
+    provenance_files: list[tuple[str, Path]],
+) -> ValidationSummary:
+    """Publish one assembled candidate with its campaign evidence."""
+    source_bundle = source_bundle.expanduser().resolve()
+    validate_bundle_root(source_bundle, case_directory)
+    source_manifest = load_json(source_bundle / "manifest.json", "bundle manifest")
+    if not provenance_files:
+        raise BundleError("golden campaign provenance must not be empty")
+    return _publish_bundle(
+        source_bundle,
+        source_manifest,
+        [],
+        output,
+        bundle_version,
+        "golden",
+        case_directory,
+        ("warm_restart", "warm_reference"),
+        provenance_files,
+    )
 
 
 def promote_bundle(
@@ -128,6 +155,7 @@ def _publish_bundle(
     bundle_class: str,
     case_directory: Path,
     matrix_warm_roles: tuple[str, ...],
+    campaign_files: list[tuple[str, Path]] | None = None,
 ) -> ValidationSummary:
     if not bundle_version.strip():
         raise BundleError("bundle version must not be empty")
@@ -160,6 +188,8 @@ def _publish_bundle(
                     source_manifest,
                     matrix_warm_roles,
                 )
+            if campaign_files is not None:
+                _install_campaign_provenance(staging, manifest, campaign_files)
             manifest["bundle_version"] = bundle_version
             manifest["bundle_class"] = bundle_class
             manifest["created_utc"] = utc_now()
@@ -169,6 +199,33 @@ def _publish_bundle(
     except OSError as exc:
         raise BundleError(f"cannot create bundle {output}: {exc}") from exc
     return result
+
+
+def _install_campaign_provenance(
+    staging: Path,
+    manifest: dict[str, Any],
+    files: list[tuple[str, Path]],
+) -> None:
+    directory = staging / "provenance/golden_campaign"
+    if directory.exists():
+        shutil.rmtree(directory)
+    for artifact_id in list(manifest["artifacts"]):
+        if artifact_id.startswith("golden_campaign_"):
+            del manifest["artifacts"][artifact_id]
+
+    for number, (relative_path, source) in enumerate(files, start=1):
+        target = directory / relative_path
+        if target.exists():
+            raise BundleError(f"duplicate campaign provenance: {relative_path}")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(require_file(source, "campaign provenance"), target)
+        register_artifact(
+            staging,
+            manifest,
+            f"golden_campaign_{number:04d}",
+            target,
+            "application/json",
+        )
 
 
 def _collect_references(

--- a/regression_tests/tools/bundle/promotion.py
+++ b/regression_tests/tools/bundle/promotion.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import shutil
 import tempfile
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -32,29 +33,36 @@ AcceptedReferences = CanonicalReference | list[MatrixRun]
 
 def promote_bundle(
     settings_path: Path,
-    summary_path: Path,
+    summary_paths: Path | Sequence[Path],
     output: Path,
     bundle_version: str,
     case_directory: Path,
 ) -> ValidationSummary:
-    """Copy a source bundle and install accepted reference results."""
+    """Copy a source bundle and install accepted reference results in order."""
     if not bundle_version.strip():
         raise BundleError("golden bundle version must not be empty")
 
     source_bundle = bundle_root_from_settings(read_settings(settings_path))
     validate_bundle_root(source_bundle, case_directory)
     source_manifest = load_json(source_bundle / "manifest.json", "bundle manifest")
-    summary_path = require_file(summary_path, "suite summary")
-    summary = load_json(summary_path, "suite summary")
-    promotion_kind = validate_promotion_summary(summary)
-    case = load_case_definition(summary["case_id"], case_directory)
-    accepted = _collect_references(
-        promotion_kind,
-        summary,
-        case,
-        source_bundle,
-        source_manifest,
-    )
+    if isinstance(summary_paths, Path):
+        summary_paths = [summary_paths]
+    if not summary_paths:
+        raise BundleError("at least one suite summary is required")
+    accepted_summaries = []
+    for path in summary_paths:
+        path = require_file(path, "suite summary")
+        summary = load_json(path, "suite summary")
+        promotion_kind = validate_promotion_summary(summary)
+        case = load_case_definition(summary["case_id"], case_directory)
+        accepted = _collect_references(
+            promotion_kind,
+            summary,
+            case,
+            source_bundle,
+            source_manifest,
+        )
+        accepted_summaries.append((path, summary, accepted, case))
 
     output = output.expanduser().resolve()
     if output.exists():
@@ -71,15 +79,16 @@ def promote_bundle(
             staging = Path(workspace) / "bundle"
             shutil.copytree(source_bundle, staging)
             manifest = load_json(staging / "manifest.json", "bundle manifest")
-            _install_references(
-                staging,
-                manifest,
-                summary_path,
-                summary,
-                accepted,
-                case,
-                source_manifest,
-            )
+            for summary_path, summary, accepted, case in accepted_summaries:
+                _install_references(
+                    staging,
+                    manifest,
+                    summary_path,
+                    summary,
+                    accepted,
+                    case,
+                    source_manifest,
+                )
             manifest["bundle_version"] = bundle_version
             manifest["bundle_class"] = "golden"
             manifest["created_utc"] = utc_now()

--- a/regression_tests/tools/bundle/promotion.py
+++ b/regression_tests/tools/bundle/promotion.py
@@ -1,4 +1,4 @@
-"""Promote accepted regression results into complete golden bundles."""
+"""Promote accepted regression results into complete bundles."""
 
 from __future__ import annotations
 
@@ -20,6 +20,11 @@ from references.canonical import (
 from references.matrix.collection import collect_matrix_runs
 from references.matrix.installation import install_reference_matrix
 from references.matrix.models import MatrixRun
+from references.mapped import (
+    MappedReferences,
+    collect_mapped_references,
+    install_mapped_references,
+)
 from references.summaries import validate_promotion_summary
 from support.documents import load_json, write_json_direct
 from support.errors import BundleError
@@ -28,7 +33,7 @@ from support.paths import require_file
 from support.time import utc_now
 
 
-AcceptedReferences = CanonicalReference | list[MatrixRun]
+AcceptedReferences = CanonicalReference | MappedReferences | list[MatrixRun]
 
 
 def promote_bundle(
@@ -37,11 +42,10 @@ def promote_bundle(
     output: Path,
     bundle_version: str,
     case_directory: Path,
+    *,
+    bundle_class: str = "golden",
 ) -> ValidationSummary:
     """Copy a source bundle and install accepted reference results in order."""
-    if not bundle_version.strip():
-        raise BundleError("golden bundle version must not be empty")
-
     source_bundle = bundle_root_from_settings(read_settings(settings_path))
     validate_bundle_root(source_bundle, case_directory)
     source_manifest = load_json(source_bundle / "manifest.json", "bundle manifest")
@@ -64,11 +68,73 @@ def promote_bundle(
         )
         accepted_summaries.append((path, summary, accepted, case))
 
+    return _publish_bundle(
+        source_bundle,
+        source_manifest,
+        accepted_summaries,
+        output,
+        bundle_version,
+        bundle_class,
+        case_directory,
+    )
+
+
+def promote_mapped_bundle(
+    settings_path: Path,
+    summary_path: Path,
+    mappings: list[dict[str, Any]],
+    output: Path,
+    bundle_version: str,
+    case_directory: Path,
+    *,
+    bundle_class: str = "candidate",
+) -> ValidationSummary:
+    """Copy a source bundle and install workflow-mapped suite outputs."""
+    source_bundle = bundle_root_from_settings(read_settings(settings_path))
+    validate_bundle_root(source_bundle, case_directory)
+    source_manifest = load_json(source_bundle / "manifest.json", "bundle manifest")
+    summary_path = require_file(summary_path, "suite summary")
+    summary = load_json(summary_path, "suite summary")
+    case = load_case_definition(summary.get("case_id", ""), case_directory)
+    accepted = collect_mapped_references(
+        summary,
+        mappings,
+        case,
+        source_bundle,
+        source_manifest,
+    )
+    return _publish_bundle(
+        source_bundle,
+        source_manifest,
+        [(summary_path, summary, accepted, case)],
+        output,
+        bundle_version,
+        bundle_class,
+        case_directory,
+    )
+
+
+def _publish_bundle(
+    source_bundle: Path,
+    source_manifest: dict[str, Any],
+    accepted_summaries: list[
+        tuple[Path, dict[str, Any], AcceptedReferences, dict[str, Any]]
+    ],
+    output: Path,
+    bundle_version: str,
+    bundle_class: str,
+    case_directory: Path,
+) -> ValidationSummary:
+    if not bundle_version.strip():
+        raise BundleError("bundle version must not be empty")
+    if bundle_class not in {"candidate", "golden"}:
+        raise BundleError(f"unsupported bundle class: {bundle_class}")
+
     output = output.expanduser().resolve()
     if output.exists():
         raise BundleError(f"output already exists: {output}")
     if is_within(output, source_bundle):
-        raise BundleError("golden output must be outside the source bundle")
+        raise BundleError("bundle output must be outside the source bundle")
 
     try:
         output.parent.mkdir(parents=True, exist_ok=True)
@@ -90,13 +156,13 @@ def promote_bundle(
                     source_manifest,
                 )
             manifest["bundle_version"] = bundle_version
-            manifest["bundle_class"] = "golden"
+            manifest["bundle_class"] = bundle_class
             manifest["created_utc"] = utc_now()
             write_json_direct(staging / "manifest.json", manifest)
             result = validate_bundle_root(staging, case_directory)
             staging.rename(output)
     except OSError as exc:
-        raise BundleError(f"cannot create golden bundle {output}: {exc}") from exc
+        raise BundleError(f"cannot create bundle {output}: {exc}") from exc
     return result
 
 
@@ -141,6 +207,9 @@ def _install_references(
             case,
             source_manifest,
         )
+        return
+    if isinstance(accepted, MappedReferences):
+        install_mapped_references(staging, manifest, accepted, case)
         return
     install_reference_matrix(
         staging,

--- a/regression_tests/tools/golden_update.py
+++ b/regression_tests/tools/golden_update.py
@@ -63,6 +63,8 @@ def update_campaign(args: argparse.Namespace) -> dict[str, Any]:
     if source_manifest["case_id"] != args.case_id:
         raise BundleError("campaign and source bundle use different cases")
 
+    selected = _selected_components(args.only, declaration)
+    partial = args.only is not None
     workspace = _workspace(args.workspace, settings, args.run_id)
     inputs = {
         "case_id": args.case_id,
@@ -74,8 +76,16 @@ def update_campaign(args: argparse.Namespace) -> dict[str, Any]:
         "output": str(args.output.expanduser().resolve()),
         "bundle_version": args.bundle_version,
         "build_jobs": args.build_jobs,
+        "only": sorted(selected) if partial else None,
     }
-    state = _load_or_create(workspace, inputs, declaration, args.output)
+    state = _load_or_create(
+        workspace,
+        inputs,
+        declaration,
+        args.output,
+        selected,
+        partial,
+    )
     if args.accept:
         _accept(state, args.accept)
     return _advance(state, args)
@@ -86,6 +96,8 @@ def _load_or_create(
     inputs: dict[str, Any],
     declaration: dict[str, Any],
     output: Path,
+    selected: set[str],
+    partial: bool,
 ) -> dict[str, Any]:
     state_path = workspace / STATE_FILE
     if state_path.is_file():
@@ -108,10 +120,17 @@ def _load_or_create(
         "active_bundle": inputs["source_bundle"],
         "active_bundle_class": "golden",
         "active_settings": None,
+        "warnings": _selection_warnings(declaration, selected, partial),
         "stages": [
             {
                 **stage,
-                "status": "pending",
+                "status": (
+                    "pending"
+                    if not partial
+                    or stage["kind"] == "verification"
+                    or stage.get("component") in selected
+                    else "skipped"
+                ),
             }
             for stage in declaration["stages"]
         ],
@@ -129,7 +148,7 @@ def _advance(state: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
             state["status"] = "awaiting_acceptance"
             _save(state)
             return state
-        if stage["status"] == "completed":
+        if stage["status"] in {"completed", "skipped"}:
             continue
         if stage["status"] == "failed":
             raise BundleError(f"golden stage failed: {stage['id']}")
@@ -171,6 +190,8 @@ def _run_stage(
     settings_path = Path(settings_record["path"])
     if _file_record(settings_path) != settings_record:
         raise BundleError("campaign settings changed")
+    if stage["kind"] == "verification":
+        _record_verification_candidate(state)
     summary_path, summary = run_suite(
         settings_path,
         stage["suite"],
@@ -304,6 +325,7 @@ def _compose_stage(
             f"{state['inputs']['bundle_version']}-{stage['id']}",
             args.cases,
             bundle_class="candidate",
+            matrix_warm_roles=("warm_restart",),
         )
     else:
         promote_mapped_bundle(
@@ -325,6 +347,19 @@ def _activate_candidate(state: dict[str, Any], stage: dict[str, Any]) -> None:
     state["active_bundle"] = stage["candidate"]
     state["active_bundle_class"] = "candidate"
     state["active_settings"] = stage["candidate_settings"]
+
+
+def _record_verification_candidate(state: dict[str, Any]) -> None:
+    root = Path(state["active_bundle"])
+    candidate = {
+        "root": str(root),
+        "manifest": _file_record(root / "manifest.json"),
+    }
+    recorded = state.get("verification_candidate")
+    if recorded is not None and recorded != candidate:
+        raise BundleError("verification candidate manifest changed")
+    state["verification_candidate"] = candidate
+    _save(state)
 
 
 def _write_bundle_settings(template: Path, output: Path, bundle: Path) -> None:
@@ -363,6 +398,44 @@ def _workspace(
     return path.resolve()
 
 
+def _selected_components(
+    requested: list[str] | None,
+    declaration: dict[str, Any],
+) -> set[str]:
+    available = {
+        stage["component"]
+        for stage in declaration["stages"]
+        if "component" in stage
+    }
+    if requested is None:
+        return available
+    selected = set(requested)
+    unknown = sorted(selected - available)
+    if unknown:
+        raise BundleError(
+            "unknown golden update component: " + ", ".join(unknown)
+        )
+    return selected
+
+
+def _selection_warnings(
+    declaration: dict[str, Any],
+    selected: set[str],
+    partial: bool,
+) -> list[str]:
+    if not partial:
+        return []
+    warnings = []
+    for group in declaration.get("update_together", []):
+        chosen = selected.intersection(group)
+        if chosen and chosen != set(group):
+            warnings.append(
+                "components normally updated together were split: "
+                + ", ".join(group)
+            )
+    return warnings
+
+
 def _file_record(path: Path) -> dict[str, Any]:
     path = path.expanduser().resolve()
     return {"path": str(path), **file_identity(path)}
@@ -382,6 +455,8 @@ def _print_status(state: dict[str, Any]) -> None:
     print(f"build: {state['build']['status']}")
     for stage in state["stages"]:
         print(f"{stage['id']}: {stage['status']}")
+    for warning in state.get("warnings", []):
+        print(f"warning: {warning}")
 
 
 def _argument_parser() -> argparse.ArgumentParser:
@@ -395,6 +470,7 @@ def _argument_parser() -> argparse.ArgumentParser:
     update.add_argument("--bundle-version", required=True, metavar="VERSION")
     update.add_argument("--workspace", type=Path)
     update.add_argument("--accept", metavar="STAGE")
+    update.add_argument("--only", action="append", metavar="COMPONENT")
     update.add_argument("--build-jobs", type=parse_build_jobs, metavar="N")
     update.add_argument("--repository-root", type=Path, default=REPOSITORY_ROOT)
     update.add_argument(

--- a/regression_tests/tools/golden_update.py
+++ b/regression_tests/tools/golden_update.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Run or resume an ordered golden-reference update."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+from build.configuration import parse_build_jobs
+from build.workflow import build_solver
+from bundle.schemas import load_validated_json
+from bundle.settings import bundle_root_from_settings, read_settings
+from bundle.validation import validate_bundle_root
+from suite.configuration import require_bundle_class
+from suite.pairs import compare_layout_pairs
+from suite.runner import run_suite
+from suite.verification import verify_suite
+from support.documents import load_json, write_json_atomic
+from support.errors import BundleError, HarnessError
+from support.files import file_identity
+from support.identifiers import IDENTIFIER_RE
+from support.paths import require_file
+from support.time import utc_now
+
+
+REGRESSION_ROOT = Path(__file__).resolve().parents[1]
+REPOSITORY_ROOT = REGRESSION_ROOT.parent
+STATE_FILE = "campaign.json"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _argument_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.action == "status":
+            state = load_json(args.workspace / STATE_FILE, "golden campaign state")
+        else:
+            state = update_campaign(args)
+    except HarnessError as exc:
+        print(f"golden update failed: {exc}", file=sys.stderr)
+        return 1
+    _print_status(state)
+    return 0
+
+
+def update_campaign(args: argparse.Namespace) -> dict[str, Any]:
+    """Create or continue one campaign until its next acceptance gate."""
+    if not IDENTIFIER_RE.fullmatch(args.run_id):
+        raise BundleError(f"invalid golden run identifier: {args.run_id}")
+    if not args.bundle_version.strip():
+        raise BundleError("golden bundle version must not be empty")
+
+    declaration = _load_declaration(args.campaigns, args.case_id)
+    source_settings = require_file(args.settings, "source settings")
+    settings = read_settings(source_settings)
+    source_bundle = bundle_root_from_settings(settings)
+    validate_bundle_root(source_bundle, args.cases)
+    require_bundle_class(source_bundle, args.cases, "golden")
+    source_manifest = load_json(source_bundle / "manifest.json", "bundle manifest")
+    if source_manifest["case_id"] != args.case_id:
+        raise BundleError("campaign and source bundle use different cases")
+
+    workspace = _workspace(args.workspace, settings, args.run_id)
+    inputs = {
+        "case_id": args.case_id,
+        "run_id": args.run_id,
+        "source_settings": _file_record(source_settings),
+        "source_bundle": str(source_bundle),
+        "source_manifest": _file_record(source_bundle / "manifest.json"),
+        "campaign_catalog": _file_record(args.campaigns),
+        "output": str(args.output.expanduser().resolve()),
+        "bundle_version": args.bundle_version,
+        "build_jobs": args.build_jobs,
+    }
+    state = _load_or_create(workspace, inputs, declaration, args.output)
+    if args.accept:
+        _accept(state, args.accept)
+    return _advance(state, args)
+
+
+def _load_or_create(
+    workspace: Path,
+    inputs: dict[str, Any],
+    declaration: dict[str, Any],
+    output: Path,
+) -> dict[str, Any]:
+    state_path = workspace / STATE_FILE
+    if state_path.is_file():
+        state = load_json(state_path, "golden campaign state")
+        if state.get("inputs") != inputs:
+            raise BundleError("golden campaign inputs changed")
+        return state
+    if workspace.exists():
+        raise BundleError(f"campaign workspace already exists: {workspace}")
+    if output.expanduser().resolve().exists():
+        raise BundleError(f"golden output already exists: {output}")
+
+    workspace.mkdir(parents=True)
+    state = {
+        "schema_version": 1,
+        "workspace": str(workspace),
+        "status": "ready",
+        "inputs": inputs,
+        "build": {"status": "pending"},
+        "stages": [
+            {
+                **stage,
+                "status": "pending",
+            }
+            for stage in declaration["stages"]
+        ],
+    }
+    _save(state)
+    return state
+
+
+def _advance(state: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    if state["build"]["status"] != "completed":
+        _run_build(state, args)
+
+    for stage in state["stages"]:
+        if stage["status"] == "awaiting_acceptance":
+            state["status"] = "awaiting_acceptance"
+            _save(state)
+            return state
+        if stage["status"] == "completed":
+            continue
+        if stage["status"] == "failed":
+            raise BundleError(f"golden stage failed: {stage['id']}")
+        _run_stage(state, stage, args)
+        if stage["status"] == "awaiting_acceptance":
+            return state
+
+    state["status"] = "stages_completed"
+    _save(state)
+    return state
+
+
+def _run_build(state: dict[str, Any], args: argparse.Namespace) -> None:
+    state["build"]["status"] = "running"
+    state["status"] = "running"
+    _save(state)
+    result = build_solver(args.settings, args.repository_root, args.build_jobs)
+    state["build"] = {
+        "status": "completed",
+        "directory": str(result.path),
+        "settings": _file_record(result.settings_path),
+        "metadata": str(result.metadata_path),
+    }
+    _save(state)
+
+
+def _run_stage(
+    state: dict[str, Any],
+    stage: dict[str, Any],
+    args: argparse.Namespace,
+) -> None:
+    resume = stage["status"] == "running"
+    stage["status"] = "running"
+    state["status"] = "running"
+    _save(state)
+
+    settings_path = Path(state["build"]["settings"]["path"])
+    if _file_record(settings_path) != state["build"]["settings"]:
+        raise BundleError("generated build settings changed")
+    summary_path, summary = run_suite(
+        settings_path,
+        stage["suite"],
+        args.cases,
+        args.layouts,
+        args.suites,
+        args.tolerances,
+        f"{state['inputs']['run_id']}-{stage['id']}",
+        "golden",
+        compare=stage["kind"] != "matrix",
+        resume=resume,
+    )
+    passed = summary["status"] == "passed"
+    stage["summary"] = str(summary_path)
+    if stage["kind"] == "matrix" and passed:
+        passed = _record_matrix_reports(state, stage, summary_path, summary, args)
+    if not passed:
+        stage["status"] = "failed"
+        state["status"] = "failed"
+        _save(state)
+        raise BundleError(f"golden stage failed: {stage['id']}")
+
+    stage["status"] = (
+        "awaiting_acceptance"
+        if stage["acceptance_required"]
+        else "completed"
+    )
+    state["status"] = stage["status"]
+    _save(state)
+
+
+def _record_matrix_reports(
+    state: dict[str, Any],
+    stage: dict[str, Any],
+    summary_path: Path,
+    summary: dict[str, Any],
+    args: argparse.Namespace,
+) -> bool:
+    comparisons = compare_layout_pairs(summary, args.cases, args.tolerances)
+    report = {
+        "schema_version": 1,
+        "status": (
+            "passed"
+            if all(item["status"] == "passed" for item in comparisons)
+            else "failed"
+        ),
+        "comparisons": comparisons,
+    }
+    report_path = Path(state["workspace"]) / "reports" / f"{stage['id']}.json"
+    write_json_atomic(report_path, report, "matrix layout-pair report")
+    stage["layout_pair_report"] = str(report_path)
+    if report["status"] != "passed":
+        return False
+    old_golden_path, _ = verify_suite(
+        summary_path,
+        args.cases,
+        args.tolerances,
+        include_layout_pairs=False,
+    )
+    stage["old_golden_report"] = str(old_golden_path)
+    return True
+
+
+def _accept(state: dict[str, Any], stage_id: str) -> None:
+    matching = [stage for stage in state["stages"] if stage["id"] == stage_id]
+    if len(matching) != 1 or matching[0]["status"] != "awaiting_acceptance":
+        raise BundleError(f"golden stage is not awaiting acceptance: {stage_id}")
+    matching[0]["status"] = "completed"
+    matching[0]["accepted_utc"] = utc_now()
+    state["status"] = "ready"
+    _save(state)
+
+
+def _load_declaration(path: Path, case_id: str) -> dict[str, Any]:
+    document = load_validated_json(
+        path,
+        path.parent / "schemas/golden-campaigns.schema.json",
+        "golden campaign catalog",
+    )
+    declaration = document["campaigns"].get(case_id)
+    if declaration is None:
+        raise BundleError(f"no golden campaign is declared for {case_id}")
+    if declaration["case"] != case_id:
+        raise BundleError(f"golden campaign {case_id} declares another case")
+    ids = [stage["id"] for stage in declaration["stages"]]
+    if len(ids) != len(set(ids)):
+        raise BundleError("golden campaign contains duplicate stage identifiers")
+    return declaration
+
+
+def _workspace(
+    configured: Path | None,
+    settings: dict[str, str],
+    run_id: str,
+) -> Path:
+    if configured is not None:
+        path = configured.expanduser()
+    else:
+        run_root = settings.get("MHDG_REGRESSION_RUN_ROOT")
+        if not run_root:
+            raise BundleError("settings must define MHDG_REGRESSION_RUN_ROOT")
+        path = Path(run_root).expanduser() / "golden_campaigns" / run_id
+    if not path.is_absolute():
+        raise BundleError("golden campaign workspace must be absolute")
+    return path.resolve()
+
+
+def _file_record(path: Path) -> dict[str, Any]:
+    path = path.expanduser().resolve()
+    return {"path": str(path), **file_identity(path)}
+
+
+def _save(state: dict[str, Any]) -> None:
+    write_json_atomic(
+        Path(state["workspace"]) / STATE_FILE,
+        state,
+        "golden campaign state",
+    )
+
+
+def _print_status(state: dict[str, Any]) -> None:
+    print(f"campaign: {state['inputs']['run_id']} ({state['status']})")
+    print(f"workspace: {state['workspace']}")
+    print(f"build: {state['build']['status']}")
+    for stage in state["stages"]:
+        print(f"{stage['id']}: {stage['status']}")
+
+
+def _argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    actions = parser.add_subparsers(dest="action", required=True)
+    update = actions.add_parser("update", help="start or continue an update")
+    update.add_argument("case_id", metavar="CASE")
+    update.add_argument("--settings", required=True, type=Path)
+    update.add_argument("--run-id", required=True)
+    update.add_argument("--output", required=True, type=Path)
+    update.add_argument("--bundle-version", required=True, metavar="VERSION")
+    update.add_argument("--workspace", type=Path)
+    update.add_argument("--accept", metavar="STAGE")
+    update.add_argument("--build-jobs", type=parse_build_jobs, metavar="N")
+    update.add_argument("--repository-root", type=Path, default=REPOSITORY_ROOT)
+    update.add_argument(
+        "--campaigns",
+        type=Path,
+        default=REGRESSION_ROOT / "golden_campaigns.json",
+    )
+    update.add_argument("--cases", type=Path, default=REGRESSION_ROOT / "cases")
+    update.add_argument(
+        "--layouts",
+        type=Path,
+        default=REGRESSION_ROOT / "layouts.json",
+    )
+    update.add_argument("--suites", type=Path, default=REGRESSION_ROOT / "suites.json")
+    update.add_argument(
+        "--tolerances",
+        type=Path,
+        default=REGRESSION_ROOT / "tolerances.json",
+    )
+    status = actions.add_parser("status", help="show persisted campaign state")
+    status.add_argument("workspace", type=Path)
+    return parser
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/regression_tests/tools/golden_update.py
+++ b/regression_tests/tools/golden_update.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from build.configuration import parse_build_jobs
 from build.workflow import build_solver
+from bundle.promotion import promote_bundle, promote_mapped_bundle
 from bundle.schemas import load_validated_json
 from bundle.settings import bundle_root_from_settings, read_settings
 from bundle.validation import validate_bundle_root
@@ -104,6 +105,9 @@ def _load_or_create(
         "status": "ready",
         "inputs": inputs,
         "build": {"status": "pending"},
+        "active_bundle": inputs["source_bundle"],
+        "active_bundle_class": "golden",
+        "active_settings": None,
         "stages": [
             {
                 **stage,
@@ -149,6 +153,7 @@ def _run_build(state: dict[str, Any], args: argparse.Namespace) -> None:
         "settings": _file_record(result.settings_path),
         "metadata": str(result.metadata_path),
     }
+    state["active_settings"] = state["build"]["settings"]
     _save(state)
 
 
@@ -162,9 +167,10 @@ def _run_stage(
     state["status"] = "running"
     _save(state)
 
-    settings_path = Path(state["build"]["settings"]["path"])
-    if _file_record(settings_path) != state["build"]["settings"]:
-        raise BundleError("generated build settings changed")
+    settings_record = state["active_settings"]
+    settings_path = Path(settings_record["path"])
+    if _file_record(settings_path) != settings_record:
+        raise BundleError("campaign settings changed")
     summary_path, summary = run_suite(
         settings_path,
         stage["suite"],
@@ -173,25 +179,41 @@ def _run_stage(
         args.suites,
         args.tolerances,
         f"{state['inputs']['run_id']}-{stage['id']}",
-        "golden",
-        compare=stage["kind"] != "matrix",
+        state["active_bundle_class"],
+        compare=stage["kind"] not in {"matrix", "reference"},
         resume=resume,
     )
     passed = summary["status"] == "passed"
     stage["summary"] = str(summary_path)
     if stage["kind"] == "matrix" and passed:
         passed = _record_matrix_reports(state, stage, summary_path, summary, args)
+    elif (
+        stage["kind"] == "reference"
+        and stage["acceptance_required"]
+        and passed
+    ):
+        old_golden_path, _ = verify_suite(
+            summary_path,
+            args.cases,
+            args.tolerances,
+        )
+        stage["old_golden_report"] = str(old_golden_path)
     if not passed:
         stage["status"] = "failed"
         state["status"] = "failed"
         _save(state)
         raise BundleError(f"golden stage failed: {stage['id']}")
 
+    if stage["kind"] in {"matrix", "reference"}:
+        _compose_stage(state, stage, summary_path, settings_path, args)
+
     stage["status"] = (
         "awaiting_acceptance"
         if stage["acceptance_required"]
         else "completed"
     )
+    if stage["status"] == "completed" and stage.get("candidate"):
+        _activate_candidate(state, stage)
     state["status"] = stage["status"]
     _save(state)
 
@@ -234,6 +256,8 @@ def _accept(state: dict[str, Any], stage_id: str) -> None:
         raise BundleError(f"golden stage is not awaiting acceptance: {stage_id}")
     matching[0]["status"] = "completed"
     matching[0]["accepted_utc"] = utc_now()
+    if matching[0].get("candidate"):
+        _activate_candidate(state, matching[0])
     state["status"] = "ready"
     _save(state)
 
@@ -252,7 +276,74 @@ def _load_declaration(path: Path, case_id: str) -> dict[str, Any]:
     ids = [stage["id"] for stage in declaration["stages"]]
     if len(ids) != len(set(ids)):
         raise BundleError("golden campaign contains duplicate stage identifiers")
+    if any(
+        stage["kind"] == "reference" and not stage.get("role_mappings")
+        for stage in declaration["stages"]
+    ):
+        raise BundleError("reference stages require role_mappings")
     return declaration
+
+
+def _compose_stage(
+    state: dict[str, Any],
+    stage: dict[str, Any],
+    summary_path: Path,
+    settings_path: Path,
+    args: argparse.Namespace,
+) -> None:
+    candidate = Path(state["workspace"]) / "candidates" / stage["id"]
+    stage["candidate"] = str(candidate)
+    _save(state)
+    if candidate.exists():
+        validate_bundle_root(candidate, args.cases)
+    elif stage["kind"] == "matrix":
+        promote_bundle(
+            settings_path,
+            summary_path,
+            candidate,
+            f"{state['inputs']['bundle_version']}-{stage['id']}",
+            args.cases,
+            bundle_class="candidate",
+        )
+    else:
+        promote_mapped_bundle(
+            settings_path,
+            summary_path,
+            stage["role_mappings"],
+            candidate,
+            f"{state['inputs']['bundle_version']}-{stage['id']}",
+            args.cases,
+        )
+
+    generated = Path(state["workspace"]) / "settings" / f"{stage['id']}.env"
+    _write_bundle_settings(settings_path, generated, candidate)
+    stage["candidate_settings"] = _file_record(generated)
+    _save(state)
+
+
+def _activate_candidate(state: dict[str, Any], stage: dict[str, Any]) -> None:
+    state["active_bundle"] = stage["candidate"]
+    state["active_bundle_class"] = "candidate"
+    state["active_settings"] = stage["candidate_settings"]
+
+
+def _write_bundle_settings(template: Path, output: Path, bundle: Path) -> None:
+    settings = read_settings(template)
+    settings["MHDG_REGRESSION_DATA_ROOT"] = str(bundle.resolve())
+    contents = "".join(
+        f"{key}={value}\n" for key, value in sorted(settings.items())
+    )
+    if output.exists():
+        if output.read_text(encoding="utf-8") != contents:
+            raise BundleError(f"generated campaign settings changed: {output}")
+        return
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_suffix(".env.tmp")
+    try:
+        temporary.write_text(contents, encoding="utf-8")
+        temporary.replace(output)
+    except OSError as exc:
+        raise BundleError(f"cannot write campaign settings {output}: {exc}") from exc
 
 
 def _workspace(

--- a/regression_tests/tools/golden_update.py
+++ b/regression_tests/tools/golden_update.py
@@ -10,7 +10,11 @@ from typing import Any
 
 from build.configuration import parse_build_jobs
 from build.workflow import build_solver
-from bundle.promotion import promote_bundle, promote_mapped_bundle
+from bundle.promotion import (
+    promote_bundle,
+    promote_mapped_bundle,
+    publish_campaign_bundle,
+)
 from bundle.schemas import load_validated_json
 from bundle.settings import bundle_root_from_settings, read_settings
 from bundle.validation import validate_bundle_root
@@ -121,6 +125,7 @@ def _load_or_create(
         "active_bundle_class": "golden",
         "active_settings": None,
         "warnings": _selection_warnings(declaration, selected, partial),
+        "publication": {"status": "pending"},
         "stages": [
             {
                 **stage,
@@ -156,9 +161,7 @@ def _advance(state: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
         if stage["status"] == "awaiting_acceptance":
             return state
 
-    state["status"] = "stages_completed"
-    _save(state)
-    return state
+    return _publish(state, args)
 
 
 def _run_build(state: dict[str, Any], args: argparse.Namespace) -> None:
@@ -170,7 +173,7 @@ def _run_build(state: dict[str, Any], args: argparse.Namespace) -> None:
         "status": "completed",
         "directory": str(result.path),
         "settings": _file_record(result.settings_path),
-        "metadata": str(result.metadata_path),
+        "metadata": _file_record(result.metadata_path),
     }
     state["active_settings"] = state["build"]["settings"]
     _save(state)
@@ -205,7 +208,7 @@ def _run_stage(
         resume=resume,
     )
     passed = summary["status"] == "passed"
-    stage["summary"] = str(summary_path)
+    stage["summary"] = _file_record(summary_path)
     if stage["kind"] == "matrix" and passed:
         passed = _record_matrix_reports(state, stage, summary_path, summary, args)
     elif (
@@ -218,7 +221,7 @@ def _run_stage(
             args.cases,
             args.tolerances,
         )
-        stage["old_golden_report"] = str(old_golden_path)
+        stage["old_golden_report"] = _file_record(old_golden_path)
     if not passed:
         stage["status"] = "failed"
         state["status"] = "failed"
@@ -258,7 +261,7 @@ def _record_matrix_reports(
     }
     report_path = Path(state["workspace"]) / "reports" / f"{stage['id']}.json"
     write_json_atomic(report_path, report, "matrix layout-pair report")
-    stage["layout_pair_report"] = str(report_path)
+    stage["layout_pair_report"] = _file_record(report_path)
     if report["status"] != "passed":
         return False
     old_golden_path, _ = verify_suite(
@@ -267,7 +270,7 @@ def _record_matrix_reports(
         args.tolerances,
         include_layout_pairs=False,
     )
-    stage["old_golden_report"] = str(old_golden_path)
+    stage["old_golden_report"] = _file_record(old_golden_path)
     return True
 
 
@@ -360,6 +363,153 @@ def _record_verification_candidate(state: dict[str, Any]) -> None:
         raise BundleError("verification candidate manifest changed")
     state["verification_candidate"] = candidate
     _save(state)
+
+
+def _publish(state: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    _record_verification_candidate(state)
+    output = Path(state["inputs"]["output"])
+    publication = state["publication"]
+    if publication["status"] == "completed":
+        if _file_record(output / "manifest.json") != publication["manifest"]:
+            raise BundleError("published golden manifest changed")
+        _validate_published(state, output, args.cases)
+        state["status"] = "published"
+        return state
+
+    if output.exists():
+        if publication["status"] != "publishing":
+            raise BundleError(f"golden output already exists: {output}")
+        _validate_published(state, output, args.cases)
+    else:
+        publication.update({"status": "publishing", "started_utc": utc_now()})
+        state["status"] = "publishing"
+        _save(state)
+        publish_campaign_bundle(
+            Path(state["active_bundle"]),
+            output,
+            state["inputs"]["bundle_version"],
+            args.cases,
+            _campaign_provenance_files(state),
+        )
+
+    publication.update(
+        {
+            "status": "completed",
+            "finished_utc": utc_now(),
+            "manifest": _file_record(output / "manifest.json"),
+        }
+    )
+    state["status"] = "published"
+    _save(state)
+    return state
+
+
+def _validate_published(
+    state: dict[str, Any],
+    output: Path,
+    case_directory: Path,
+) -> None:
+    validate_bundle_root(output, case_directory)
+    manifest = load_json(output / "manifest.json", "published bundle manifest")
+    candidate = load_json(
+        Path(state["active_bundle"]) / "manifest.json",
+        "candidate bundle manifest",
+    )
+    expected = {
+        "bundle_id": candidate["bundle_id"],
+        "bundle_version": state["inputs"]["bundle_version"],
+        "bundle_class": "golden",
+        "case_id": state["inputs"]["case_id"],
+    }
+    if any(manifest.get(name) != value for name, value in expected.items()):
+        raise BundleError("published golden bundle does not match campaign")
+    records = [
+        artifact
+        for artifact in manifest["artifacts"].values()
+        if artifact["path"] == "provenance/golden_campaign/campaign.json"
+    ]
+    if len(records) != 1:
+        raise BundleError("published golden bundle has no campaign state")
+    recorded = load_json(output / records[0]["path"], "published campaign state")
+    if (
+        recorded.get("workspace") != state["workspace"]
+        or recorded.get("verification_candidate")
+        != state["verification_candidate"]
+    ):
+        raise BundleError("published golden bundle belongs to another campaign")
+
+
+def _campaign_provenance_files(state: dict[str, Any]) -> list[tuple[str, Path]]:
+    workspace = Path(state["workspace"])
+    build_record = state["build"]["metadata"]
+    build_metadata = Path(build_record["path"])
+    if _file_record(build_metadata) != build_record:
+        raise BundleError("campaign build metadata changed")
+    files = [
+        ("campaign.json", workspace / STATE_FILE),
+        ("declaration.json", Path(state["inputs"]["campaign_catalog"]["path"])),
+        ("build/build_metadata.json", build_metadata),
+    ]
+    for stage in state["stages"]:
+        summary_record = stage.get("summary")
+        if summary_record is None:
+            continue
+        summary_path = _recorded_path(summary_record, "suite summary")
+        prefix = f"stages/{stage['id']}"
+        documents = [("suite_summary.json", summary_path)]
+        documents.extend(
+            (f"{name}.json", _recorded_path(stage[name], name))
+            for name in ("layout_pair_report", "old_golden_report")
+            if name in stage
+        )
+        report_paths = set()
+        for name, path in documents:
+            files.append((f"{prefix}/{name}", path))
+            report_paths.update(_comparison_report_paths(load_json(path, name)))
+
+        summary = load_json(summary_path, "suite summary")
+        if summary.get("execution_inputs", {}).get("build_manifest") != build_record:
+            raise BundleError(f"golden stage used another build: {stage['id']}")
+        for number, result in enumerate(summary.get("results", []), start=1):
+            run = Path(result["run_directory"])
+            run_prefix = f"{prefix}/runs/{number:03d}"
+            for name in ("run_plan.json", "run_metadata.json"):
+                files.append((f"{run_prefix}/{name}", run / name))
+                for nested in sorted(run.glob(f"stages/*/{name}")):
+                    files.append(
+                        (
+                            f"{run_prefix}/stages/{nested.parent.name}/{name}",
+                            nested,
+                        )
+                    )
+        for number, path in enumerate(sorted(report_paths), start=1):
+            files.append((f"{prefix}/comparisons/{number:03d}.json", path))
+    return files
+
+
+def _comparison_report_paths(document: Any) -> set[Path]:
+    if isinstance(document, dict):
+        paths = {
+            Path(value)
+            for name, value in document.items()
+            if name == "comparison_report" and isinstance(value, str)
+        }
+        for value in document.values():
+            paths.update(_comparison_report_paths(value))
+        return paths
+    if isinstance(document, list):
+        paths = set()
+        for value in document:
+            paths.update(_comparison_report_paths(value))
+        return paths
+    return set()
+
+
+def _recorded_path(record: dict[str, Any], label: str) -> Path:
+    path = Path(record["path"])
+    if _file_record(path) != record:
+        raise BundleError(f"campaign {label} changed")
+    return path
 
 
 def _write_bundle_settings(template: Path, output: Path, bundle: Path) -> None:
@@ -457,6 +607,8 @@ def _print_status(state: dict[str, Any]) -> None:
         print(f"{stage['id']}: {stage['status']}")
     for warning in state.get("warnings", []):
         print(f"warning: {warning}")
+    if state.get("publication", {}).get("status") == "completed":
+        print(f"output: {state['inputs']['output']}")
 
 
 def _argument_parser() -> argparse.ArgumentParser:

--- a/regression_tests/tools/promote_bundle.py
+++ b/regression_tests/tools/promote_bundle.py
@@ -13,7 +13,13 @@ from support.errors import HarnessError
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("suite_summary", metavar="SUITE_SUMMARY", type=Path)
+    parser.add_argument(
+        "suite_summaries",
+        metavar="SUITE_SUMMARY",
+        nargs="+",
+        type=Path,
+        help="accepted summaries to apply in order",
+    )
     parser.add_argument("--output", required=True, type=Path)
     parser.add_argument("--bundle-version", required=True, metavar="VERSION")
     parser.add_argument("--settings", required=True, type=Path)
@@ -23,7 +29,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         result = promotion.promote_bundle(
             args.settings,
-            args.suite_summary,
+            args.suite_summaries,
             args.output,
             args.bundle_version,
             args.cases,

--- a/regression_tests/tools/references/mapped.py
+++ b/regression_tests/tools/references/mapped.py
@@ -1,0 +1,134 @@
+"""Collect suite outputs and install them into declared workflow roles."""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from bundle.artifacts import validate_bundle_identity
+from comparison.shared.outputs import select_candidate
+from support.documents import load_json
+from support.errors import BundleError
+from support.files import file_identity, is_within
+from support.paths import recorded_directory
+
+
+@dataclass(frozen=True)
+class MappedReference:
+    role: str
+    solution: Path
+
+
+@dataclass(frozen=True)
+class MappedReferences:
+    items: tuple[MappedReference, ...]
+
+
+def collect_mapped_references(
+    summary: dict[str, Any],
+    mappings: list[dict[str, Any]],
+    case: dict[str, Any],
+    source_bundle: Path,
+    source_manifest: dict[str, Any],
+) -> MappedReferences:
+    """Select completed suite outputs using workflow-declared roles."""
+    if (
+        summary.get("schema_version") != 2
+        or summary.get("status") != "passed"
+        or summary.get("case_id") != case["case_id"]
+    ):
+        raise BundleError("mapped references require a passing version-2 suite")
+
+    references = []
+    for mapping in mappings:
+        workflow_id = mapping["workflow"]
+        workflow = case["workflows"].get(workflow_id)
+        if workflow is None:
+            raise BundleError(f"mapped reference uses unknown workflow {workflow_id}")
+        layout_id = workflow.get("default_layout")
+        allowed_roles = {
+            role
+            for name in ("restart_role", "reference_role")
+            if (role := workflow.get(name))
+        }
+        unknown = sorted(set(mapping["roles"]) - allowed_roles)
+        if unknown:
+            raise BundleError(
+                f"workflow {workflow_id} does not declare roles: "
+                + ", ".join(unknown)
+            )
+        result = _selected_result(summary, workflow_id, layout_id)
+        run = recorded_directory(result.get("run_directory"), "mapped run")
+        plan = load_json(run / "run_plan.json", "run plan")
+        metadata = load_json(run / "run_metadata.json", "run metadata")
+        expected = {
+            "case_id": case["case_id"],
+            "workflow_id": workflow_id,
+            "layout_id": layout_id,
+        }
+        if any(plan.get(name) != value for name, value in expected.items()):
+            raise BundleError(f"mapped run has inconsistent identity: {workflow_id}")
+        if metadata.get("status") != "completed":
+            raise BundleError(f"mapped run is incomplete: {workflow_id}")
+        validate_bundle_identity(plan, source_bundle, source_manifest)
+        solution = select_candidate(run, metadata)
+        if not is_within(solution, run):
+            raise BundleError("mapped solution is outside its run directory")
+        references.extend(
+            MappedReference(role, solution) for role in mapping["roles"]
+        )
+    return MappedReferences(tuple(references))
+
+
+def install_mapped_references(
+    staging: Path,
+    manifest: dict[str, Any],
+    references: MappedReferences,
+    case: dict[str, Any],
+) -> None:
+    """Replace only the declared bundle roles."""
+    for reference in references.items:
+        specification = case["bundle_files"][reference.role]
+        artifact_id = manifest["roles"].get(
+            reference.role,
+            specification["artifact_id"],
+        )
+        existing = manifest["artifacts"].get(artifact_id)
+        target = (
+            staging / existing["path"]
+            if existing is not None
+            else staging / "inputs" / specification["filename"]
+        )
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(reference.solution, target)
+        artifact = {
+            "path": target.relative_to(staging).as_posix(),
+            **file_identity(target),
+            "media_type": specification["media_type"],
+        }
+        if specification["optional"]:
+            artifact["optional"] = True
+        manifest["roles"][reference.role] = artifact_id
+        manifest["artifacts"][artifact_id] = artifact
+
+
+def _selected_result(
+    summary: dict[str, Any],
+    workflow_id: str,
+    layout_id: str,
+) -> dict[str, Any]:
+    matching = [
+        result
+        for result in summary.get("results", [])
+        if result.get("workflow_id") == workflow_id
+        and result.get("layout_id") == layout_id
+        and result.get("status") == "passed"
+        and result.get("run_status") == "completed"
+    ]
+    if len(matching) != 1:
+        raise BundleError(
+            f"suite has no unique completed result for {workflow_id}/{layout_id}"
+        )
+    return matching[0]

--- a/regression_tests/tools/references/matrix/installation.py
+++ b/regression_tests/tools/references/matrix/installation.py
@@ -27,6 +27,7 @@ def install_reference_matrix(
     runs: list[MatrixRun],
     case: dict[str, Any],
     source_manifest: dict[str, Any],
+    canonical_warm_roles: tuple[str, ...] = ("warm_restart", "warm_reference"),
 ) -> None:
     """Copy selected stage outputs and add one generated bundle role."""
     references_directory = staging / "references/matrix"
@@ -84,8 +85,14 @@ def install_reference_matrix(
     if manifest["case_id"] != case["case_id"]:
         raise BundleError("source bundle contains another case")
     manifest["roles"][REFERENCE_MATRIX_ROLE] = REFERENCE_MATRIX_ID
-    if summary["suite_id"] == "cold_matrix":
-        _install_canonical_warm_state(staging, manifest, runs, case)
+    if summary["suite_id"] == "cold_matrix" and canonical_warm_roles:
+        _install_canonical_warm_state(
+            staging,
+            manifest,
+            runs,
+            case,
+            canonical_warm_roles,
+        )
 
 
 def _install_canonical_warm_state(
@@ -93,6 +100,7 @@ def _install_canonical_warm_state(
     manifest: dict[str, Any],
     runs: list[MatrixRun],
     case: dict[str, Any],
+    roles: tuple[str, ...],
 ) -> None:
     """Use the canonical cold final state for warm restart and reference."""
     canonical_layout = case["workflows"]["cold_fixed"]["default_layout"]
@@ -106,7 +114,7 @@ def _install_canonical_warm_state(
             "cold matrix has no unique canonical cold_fixed final state"
         )
     solution = matching[0].stages[-1].solution
-    for role in ("warm_restart", "warm_reference"):
+    for role in roles:
         artifact_id = manifest["roles"].get(role)
         artifact = manifest["artifacts"].get(artifact_id)
         if artifact is None:

--- a/regression_tests/tools/suite/configuration.py
+++ b/regression_tests/tools/suite/configuration.py
@@ -33,9 +33,11 @@ def load_suite_definition(
     if "layout_comparisons" in declaration:
         suite["layout_comparisons"] = declaration["layout_comparisons"]
         suite["tolerance_profile"] = declaration["tolerance_profile"]
-        for option in ("layout_comparison_policy", "reference_comparisons"):
+        for option in ("layout_comparison_policy",):
             if option in declaration:
                 suite[option] = declaration[option]
+    if "reference_comparisons" in declaration:
+        suite["reference_comparisons"] = declaration["reference_comparisons"]
 
     layouts = load_layouts(layouts_path)
     unknown_layouts = [

--- a/regression_tests/tools/suite/runner.py
+++ b/regression_tests/tools/suite/runner.py
@@ -143,6 +143,8 @@ def _comparison_mode(
     reference_comparisons: bool,
     compare: bool,
 ) -> str:
+    if not layout_pairs and not reference_comparisons:
+        return "execution_only"
     if not compare:
         return "deferred" if reference_comparisons else "deferred_layout_pairs"
     if layout_pairs and reference_comparisons:

--- a/regression_tests/tools/suite/verification.py
+++ b/regression_tests/tools/suite/verification.py
@@ -18,6 +18,8 @@ def verify_suite(
     suite_summary_path: Path,
     case_directory: Path,
     tolerances_path: Path,
+    *,
+    include_layout_pairs: bool = True,
 ) -> tuple[Path, dict[str, Any]]:
     """Compare all recorded suite runs without executing the solver."""
     suite_summary_path = require_file(suite_summary_path, "suite summary")
@@ -44,7 +46,7 @@ def verify_suite(
             )
             write_json_atomic(output_path, summary, "verification summary")
 
-    if source.get("layout_comparisons"):
+    if include_layout_pairs and source.get("layout_comparisons"):
         summary["comparisons"] = compare_layout_pairs(
             source,
             case_directory,


### PR DESCRIPTION
Adds a declaration-driven `golden update` workflow that:

- Builds once and runs ordered full or component-scoped golden updates.
- Stops at explicit acceptance gates and resumes safely.
- Composes cold, warm, and impurity references using existing harness machinery.
- Verifies the exact candidate before atomic publication.
- Retains campaign, build, run, comparison, and acceptance provenance.


