### PR TITLE
Feature/pr03 bohm gyrobohm taper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *lib/*.o
 *lib/*.*mod
 *lib/MHDG-*
+*lib/*_check
 *MHDG-*
 *src_*
 *test/res*

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -107,7 +107,7 @@ magnetic_topology.o : magnetic_topology.F interpolation.o
 magnetic_geometry_state.F : $(SDIR)/Models/magnetic_geometry_state.f90
 	$(CMP) -s $< $@ || $(CP) -f $< $@
 
-magnetic_geometry_state.o : magnetic_geometry_state.F magnetic_topology.o
+magnetic_geometry_state.o : magnetic_geometry_state.F magnetic_topology.o prec_const.o
 	$(FC) -c $(FCFLAGS) $(INC)  $< -o $@
 
 external_heating.F : $(SDIR)/Models/external_heating.f90

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -5,7 +5,7 @@
 #---------------------------------------
 include Make.inc/arch.make
 
-.PHONY : clean
+.PHONY : clean check-magnetic-topology
 
 all : allseq
 
@@ -35,6 +35,11 @@ clean:
 	@echo "Cleaning *.o *.mod *.F"
 	$(RM) *.o *.mod *.kmo  *.F *.f90 *.F90
 	$(RM) MHDG-* Convergence *~
+	$(RM) magnetic_topology_check
+
+check-magnetic-topology : interpolation.o magnetic_topology.o
+	$(FC) $(FCFLAGS) $(INC) -I. ../unit_tests/fortran/test_magnetic_topology.f90 interpolation.o magnetic_topology.o -o magnetic_topology_check
+	./magnetic_topology_check
 
 include Make.inc/build_provenance.mk
 
@@ -77,7 +82,13 @@ MPI_OMP.o : MPI_OMP.F globals.o
 magnetic_field.F : $(SDIR)/Models/magnetic_field.f90
 	$(CMP) -s $< $@ || $(CP) -f $< $@
 
-magnetic_field.o : magnetic_field.F globals.o prec_const.o HDF5_io.o MPI_OMP.o interpolation.o
+magnetic_field.o : magnetic_field.F globals.o prec_const.o HDF5_io.o MPI_OMP.o interpolation.o magnetic_topology.o
+	$(FC) -c $(FCFLAGS) $(INC)  $< -o $@
+
+magnetic_topology.F : $(SDIR)/Models/magnetic_topology.f90
+	$(CMP) -s $< $@ || $(CP) -f $< $@
+
+magnetic_topology.o : magnetic_topology.F interpolation.o
 	$(FC) -c $(FCFLAGS) $(INC)  $< -o $@
 
 external_heating.F : $(SDIR)/Models/external_heating.f90
@@ -408,14 +419,14 @@ Convergence.F : $(SDIR)/Convergence.f90
 Convergence.o : Convergence.F inout.o gmsh_io.o reference_element.o MPI_OMP.o PrintUtils.o Debug.o initialization.o Postprocess.o
 	$(FC) -c $(FCFLAGS) $(INC)  $< -o $@
 
-MHDG-$(MDL)-$(MODE)-$(DIM) : Main_utils.o MPI_OMP.o matrices_types.o interpolation.o PrintUtils.o prec_const.o types.o globals.o adimensionalization.o Debug.o LinearAlgebra.o magnetic_field.o external_heating.o $(IMPURITY_RADIATION_OBJECT) physics.o read_input.o HDF5_io.o $(BUILD_PROVENANCE_OBJECT) flux_surface_transport_data.o transport_models_1d_config.o transport_models_1d_derived.o transport_models_1d.o transport_models_1d_update.o transport_models_1d_diffusion_bohm_gyrobohm.o transport_models_1d_common.o transport_models_1d_pinch.o transport_models_1d_io.o transport_models_1d_runtime.o inout.o gmsh_io.o gmsh.o reference_element.o preprocess.o analytical.o initialization.o element_mapping.o adaptivity_projection.o hdg_PrecalculatedFirstEquation.o hdg_ComputeJacobian.o  $(ADDMOD) hdg_Mapping.o hdg_BC.o hdg_Assembly.o solve_global_system.o compute_element_solution.o adaptivity_general.o adaptivity_common.o mod_splines.o adaptivity_estimator.o adaptivity_indicator.o  domain_decomposition.o MHDG.o
-	$(FC) $(FCFLAGS)  Main_utils.o MPI_OMP.o matrices_types.o interpolation.o PrintUtils.o prec_const.o types.o globals.o adimensionalization.o Debug.o LinearAlgebra.o magnetic_field.o external_heating.o $(IMPURITY_RADIATION_OBJECT) physics.o read_input.o HDF5_io.o $(BUILD_PROVENANCE_OBJECT) flux_surface_transport_data.o transport_models_1d_config.o transport_models_1d_derived.o transport_models_1d.o transport_models_1d_update.o transport_models_1d_diffusion_bohm_gyrobohm.o transport_models_1d_common.o transport_models_1d_pinch.o transport_models_1d_io.o transport_models_1d_runtime.o inout.o gmsh_io.o gmsh.o reference_element.o preprocess.o analytical.o initialization.o element_mapping.o adaptivity_projection.o hdg_PrecalculatedFirstEquation.o hdg_ComputeJacobian.o  Postprocess.o $(ADDMOD) hdg_Mapping.o hdg_BC.o hdg_Assembly.o  solve_global_system.o compute_element_solution.o mod_splines.o adaptivity_general.o adaptivity_common.o adaptivity_indicator.o adaptivity_estimator.o domain_decomposition.o MHDG.o -o MHDG-$(MDL)-$(MODE)-$(DIM) $(LIB)
+MHDG-$(MDL)-$(MODE)-$(DIM) : Main_utils.o MPI_OMP.o matrices_types.o interpolation.o magnetic_topology.o PrintUtils.o prec_const.o types.o globals.o adimensionalization.o Debug.o LinearAlgebra.o magnetic_field.o external_heating.o $(IMPURITY_RADIATION_OBJECT) physics.o read_input.o HDF5_io.o $(BUILD_PROVENANCE_OBJECT) flux_surface_transport_data.o transport_models_1d_config.o transport_models_1d_derived.o transport_models_1d.o transport_models_1d_update.o transport_models_1d_diffusion_bohm_gyrobohm.o transport_models_1d_common.o transport_models_1d_pinch.o transport_models_1d_io.o transport_models_1d_runtime.o inout.o gmsh_io.o gmsh.o reference_element.o preprocess.o analytical.o initialization.o element_mapping.o adaptivity_projection.o hdg_PrecalculatedFirstEquation.o hdg_ComputeJacobian.o  $(ADDMOD) hdg_Mapping.o hdg_BC.o hdg_Assembly.o solve_global_system.o compute_element_solution.o adaptivity_general.o adaptivity_common.o mod_splines.o adaptivity_estimator.o adaptivity_indicator.o  domain_decomposition.o MHDG.o
+	$(FC) $(FCFLAGS)  Main_utils.o MPI_OMP.o matrices_types.o interpolation.o magnetic_topology.o PrintUtils.o prec_const.o types.o globals.o adimensionalization.o Debug.o LinearAlgebra.o magnetic_field.o external_heating.o $(IMPURITY_RADIATION_OBJECT) physics.o read_input.o HDF5_io.o $(BUILD_PROVENANCE_OBJECT) flux_surface_transport_data.o transport_models_1d_config.o transport_models_1d_derived.o transport_models_1d.o transport_models_1d_update.o transport_models_1d_diffusion_bohm_gyrobohm.o transport_models_1d_common.o transport_models_1d_pinch.o transport_models_1d_io.o transport_models_1d_runtime.o inout.o gmsh_io.o gmsh.o reference_element.o preprocess.o analytical.o initialization.o element_mapping.o adaptivity_projection.o hdg_PrecalculatedFirstEquation.o hdg_ComputeJacobian.o  Postprocess.o $(ADDMOD) hdg_Mapping.o hdg_BC.o hdg_Assembly.o  solve_global_system.o compute_element_solution.o mod_splines.o adaptivity_general.o adaptivity_common.o adaptivity_indicator.o adaptivity_estimator.o domain_decomposition.o MHDG.o -o MHDG-$(MDL)-$(MODE)-$(DIM) $(LIB)
 	/bin/cp -f MHDG-$(MDL)-$(MODE)-$(DIM) ../test/
 #	/bin/cp -f MHDG-$(MDL)-$(MODE)-$(DIM) ../test_anal/
 #	/bin/cp -f MHDG-$(MDL)-$(MODE)-$(DIM) ../test_psblas/
 
-Convergence-$(MDL)-$(DIM) : MPI_OMP.o matrices_types.o interpolation.o PrintUtils.o prec_const.o types.o globals.o adimensionalization.o Debug.o LinearAlgebra.o magnetic_field.o external_heating.o $(IMPURITY_RADIATION_OBJECT) physics.o read_input.o HDF5_io.o $(BUILD_PROVENANCE_OBJECT) flux_surface_transport_data.o transport_models_1d_config.o transport_models_1d_derived.o transport_models_1d.o transport_models_1d_update.o transport_models_1d_diffusion_bohm_gyrobohm.o transport_models_1d_common.o transport_models_1d_pinch.o transport_models_1d_io.o transport_models_1d_runtime.o inout.o gmsh_io.o gmsh.o reference_element.o preprocess.o analytical.o initialization.o hdg_PrecalculatedFirstEquation.o hdg_ComputeJacobian.o  $(ADDMOD) hdg_Mapping.o hdg_BC.o hdg_Assembly.o solve_global_system.o compute_element_solution.o adaptivity_general.o adaptivity_common.o  mod_splines.o Convergence.o
-	$(FC) $(FCFLAGS) $(OBJS) MPI_OMP.o matrices_types.o interpolation.o PrintUtils.o prec_const.o types.o globals.o adimensionalization.o Debug.o LinearAlgebra.o magnetic_field.o external_heating.o $(IMPURITY_RADIATION_OBJECT) physics.o read_input.o HDF5_io.o $(BUILD_PROVENANCE_OBJECT) flux_surface_transport_data.o transport_models_1d_config.o transport_models_1d_derived.o transport_models_1d.o transport_models_1d_update.o transport_models_1d_diffusion_bohm_gyrobohm.o transport_models_1d_common.o transport_models_1d_pinch.o transport_models_1d_io.o transport_models_1d_runtime.o inout.o gmsh_io.o gmsh.o reference_element.o preprocess.o analytical.o initialization.o hdg_PrecalculatedFirstEquation.o hdg_ComputeJacobian.o  Postprocess.o $(ADDMOD) hdg_Mapping.o hdg_BC.o hdg_Assembly.o  solve_global_system.o compute_element_solution.o adaptivity_general.o adaptivity_common.o mod_splines.o Convergence.o -o Convergence-$(MDL)-$(MODE)-$(DIM) $(LIB)
+Convergence-$(MDL)-$(DIM) : MPI_OMP.o matrices_types.o interpolation.o magnetic_topology.o PrintUtils.o prec_const.o types.o globals.o adimensionalization.o Debug.o LinearAlgebra.o magnetic_field.o external_heating.o $(IMPURITY_RADIATION_OBJECT) physics.o read_input.o HDF5_io.o $(BUILD_PROVENANCE_OBJECT) flux_surface_transport_data.o transport_models_1d_config.o transport_models_1d_derived.o transport_models_1d.o transport_models_1d_update.o transport_models_1d_diffusion_bohm_gyrobohm.o transport_models_1d_common.o transport_models_1d_pinch.o transport_models_1d_io.o transport_models_1d_runtime.o inout.o gmsh_io.o gmsh.o reference_element.o preprocess.o analytical.o initialization.o hdg_PrecalculatedFirstEquation.o hdg_ComputeJacobian.o  $(ADDMOD) hdg_Mapping.o hdg_BC.o hdg_Assembly.o solve_global_system.o compute_element_solution.o adaptivity_general.o adaptivity_common.o  mod_splines.o Convergence.o
+	$(FC) $(FCFLAGS) $(OBJS) MPI_OMP.o matrices_types.o interpolation.o magnetic_topology.o PrintUtils.o prec_const.o types.o globals.o adimensionalization.o Debug.o LinearAlgebra.o magnetic_field.o external_heating.o $(IMPURITY_RADIATION_OBJECT) physics.o read_input.o HDF5_io.o $(BUILD_PROVENANCE_OBJECT) flux_surface_transport_data.o transport_models_1d_config.o transport_models_1d_derived.o transport_models_1d.o transport_models_1d_update.o transport_models_1d_diffusion_bohm_gyrobohm.o transport_models_1d_common.o transport_models_1d_pinch.o transport_models_1d_io.o transport_models_1d_runtime.o inout.o gmsh_io.o gmsh.o reference_element.o preprocess.o analytical.o initialization.o hdg_PrecalculatedFirstEquation.o hdg_ComputeJacobian.o  Postprocess.o $(ADDMOD) hdg_Mapping.o hdg_BC.o hdg_Assembly.o  solve_global_system.o compute_element_solution.o adaptivity_general.o adaptivity_common.o mod_splines.o Convergence.o -o Convergence-$(MDL)-$(MODE)-$(DIM) $(LIB)
 	/bin/cp -f Convergence-$(MDL)-$(MODE)-$(DIM) ../test/
 #	/bin/cp -f Convergence-$(MDL)-$(MODE)-$(DIM) ../test_anal/
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -5,7 +5,7 @@
 #---------------------------------------
 include Make.inc/arch.make
 
-.PHONY : clean check-magnetic-topology check-magnetic-geometry
+.PHONY : clean check-magnetic-topology check-magnetic-geometry check-transport-region-policy
 
 all : allseq
 
@@ -36,6 +36,7 @@ clean:
 	$(RM) *.o *.mod *.kmo  *.F *.f90 *.F90
 	$(RM) MHDG-* Convergence *~
 	$(RM) magnetic_topology_check magnetic_geometry_check
+	$(RM) transport_region_policy_check
 
 check-magnetic-topology : interpolation.o magnetic_topology.o
 	$(FC) $(FCFLAGS) $(INC) -I. ../unit_tests/fortran/test_magnetic_topology.f90 interpolation.o magnetic_topology.o -o magnetic_topology_check
@@ -44,6 +45,10 @@ check-magnetic-topology : interpolation.o magnetic_topology.o
 check-magnetic-geometry : interpolation.o magnetic_topology.o magnetic_geometry_state.o
 	$(FC) $(FCFLAGS) $(INC) -I. ../unit_tests/fortran/test_magnetic_geometry_state.f90 interpolation.o magnetic_topology.o magnetic_geometry_state.o -o magnetic_geometry_check
 	./magnetic_geometry_check
+
+check-transport-region-policy : interpolation.o magnetic_topology.o transport_models_1d_config.o
+	$(FC) $(FCFLAGS) $(INC) -I. ../unit_tests/fortran/test_transport_region_policy.f90 interpolation.o magnetic_topology.o transport_models_1d_config.o -o transport_region_policy_check
+	./transport_region_policy_check
 
 include Make.inc/build_provenance.mk
 
@@ -240,13 +245,13 @@ preprocess.o : preprocess.F globals.o PrintUtils.o types.o MPI_OMP.o
 flux_surface_transport_data.F : $(SDIR)/Models/$(RMDL)/transport_1d/flux_surface_transport_data.f90
 	$(CMP) -s $< $@ || $(CP) -f $< $@
 
-flux_surface_transport_data.o : flux_surface_transport_data.F globals.o MPI_OMP.o HDF5_io.o interpolation.o
+flux_surface_transport_data.o : flux_surface_transport_data.F globals.o MPI_OMP.o HDF5_io.o interpolation.o magnetic_geometry_state.o transport_models_1d_config.o
 	$(FC) -c $(FCFLAGS) $(INC)  $< -o $@
 
 transport_models_1d_config.F : $(SDIR)/Models/$(RMDL)/transport_1d/transport_models_1d_config.f90
 	$(CMP) -s $< $@ || $(CP) -f $< $@
 
-transport_models_1d_config.o : transport_models_1d_config.F
+transport_models_1d_config.o : transport_models_1d_config.F magnetic_topology.o
 	$(FC) -c $(FCFLAGS) $(INC)  $< -o $@
 
 transport_models_1d_derived.F : $(SDIR)/Models/$(RMDL)/transport_1d/transport_models_1d_derived.f90

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -5,7 +5,7 @@
 #---------------------------------------
 include Make.inc/arch.make
 
-.PHONY : clean check-magnetic-topology check-magnetic-geometry check-transport-region-policy
+.PHONY : clean check-magnetic-topology check-magnetic-geometry check-transport-region-policy check-transport-taper
 
 all : allseq
 
@@ -36,7 +36,7 @@ clean:
 	$(RM) *.o *.mod *.kmo  *.F *.f90 *.F90
 	$(RM) MHDG-* Convergence *~
 	$(RM) magnetic_topology_check magnetic_geometry_check
-	$(RM) transport_region_policy_check
+	$(RM) transport_region_policy_check transport_taper_check
 
 check-magnetic-topology : interpolation.o magnetic_topology.o
 	$(FC) $(FCFLAGS) $(INC) -I. ../unit_tests/fortran/test_magnetic_topology.f90 interpolation.o magnetic_topology.o -o magnetic_topology_check
@@ -49,6 +49,10 @@ check-magnetic-geometry : interpolation.o magnetic_topology.o magnetic_geometry_
 check-transport-region-policy : interpolation.o magnetic_topology.o transport_models_1d_config.o
 	$(FC) $(FCFLAGS) $(INC) -I. ../unit_tests/fortran/test_transport_region_policy.f90 interpolation.o magnetic_topology.o transport_models_1d_config.o -o transport_region_policy_check
 	./transport_region_policy_check
+
+check-transport-taper : interpolation.o magnetic_topology.o transport_models_1d_config.o
+	$(FC) $(FCFLAGS) $(INC) -I. ../unit_tests/fortran/test_transport_taper.f90 interpolation.o magnetic_topology.o transport_models_1d_config.o -o transport_taper_check
+	./transport_taper_check
 
 include Make.inc/build_provenance.mk
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -5,7 +5,7 @@
 #---------------------------------------
 include Make.inc/arch.make
 
-.PHONY : clean check-magnetic-topology
+.PHONY : clean check-magnetic-topology check-magnetic-geometry
 
 all : allseq
 
@@ -35,11 +35,15 @@ clean:
 	@echo "Cleaning *.o *.mod *.F"
 	$(RM) *.o *.mod *.kmo  *.F *.f90 *.F90
 	$(RM) MHDG-* Convergence *~
-	$(RM) magnetic_topology_check
+	$(RM) magnetic_topology_check magnetic_geometry_check
 
 check-magnetic-topology : interpolation.o magnetic_topology.o
 	$(FC) $(FCFLAGS) $(INC) -I. ../unit_tests/fortran/test_magnetic_topology.f90 interpolation.o magnetic_topology.o -o magnetic_topology_check
 	./magnetic_topology_check
+
+check-magnetic-geometry : interpolation.o magnetic_topology.o magnetic_geometry_state.o
+	$(FC) $(FCFLAGS) $(INC) -I. ../unit_tests/fortran/test_magnetic_geometry_state.f90 interpolation.o magnetic_topology.o magnetic_geometry_state.o -o magnetic_geometry_check
+	./magnetic_geometry_check
 
 include Make.inc/build_provenance.mk
 
@@ -82,13 +86,19 @@ MPI_OMP.o : MPI_OMP.F globals.o
 magnetic_field.F : $(SDIR)/Models/magnetic_field.f90
 	$(CMP) -s $< $@ || $(CP) -f $< $@
 
-magnetic_field.o : magnetic_field.F globals.o prec_const.o HDF5_io.o MPI_OMP.o interpolation.o magnetic_topology.o
+magnetic_field.o : magnetic_field.F globals.o prec_const.o HDF5_io.o MPI_OMP.o interpolation.o magnetic_topology.o magnetic_geometry_state.o
 	$(FC) -c $(FCFLAGS) $(INC)  $< -o $@
 
 magnetic_topology.F : $(SDIR)/Models/magnetic_topology.f90
 	$(CMP) -s $< $@ || $(CP) -f $< $@
 
 magnetic_topology.o : magnetic_topology.F interpolation.o
+	$(FC) -c $(FCFLAGS) $(INC)  $< -o $@
+
+magnetic_geometry_state.F : $(SDIR)/Models/magnetic_geometry_state.f90
+	$(CMP) -s $< $@ || $(CP) -f $< $@
+
+magnetic_geometry_state.o : magnetic_geometry_state.F magnetic_topology.o
 	$(FC) -c $(FCFLAGS) $(INC)  $< -o $@
 
 external_heating.F : $(SDIR)/Models/external_heating.f90
@@ -129,7 +139,7 @@ PrintUtils.o : PrintUtils.F matrices_types.o MPI_OMP.o
 Communications.F : $(SDIR)/MPI_OMP/Communications.f90
 	$(CMP) -s $< $@ || $(CP) -f $< $@
 
-Communications.o : Communications.F MPI_OMP.o preprocess.o PrintUtils.o globals.o
+Communications.o : Communications.F MPI_OMP.o preprocess.o PrintUtils.o globals.o magnetic_geometry_state.o
 	$(FC) -c $(FCFLAGS) $(INC)  $< -o $@
 
 interpolation.F : $(SDIR)/LinearAlgebra/interpolation.f90
@@ -153,7 +163,7 @@ LinearAlgebra.o : LinearAlgebra.F
 inout.F : $(SDIR)/InOut/inout.f90
 	$(CMP) -s $< $@ || $(CP) -f $< $@
 
-inout.o : inout.F $(BUILD_PROVENANCE_OBJECT) HDF5_io.o flux_surface_transport_data.o transport_models_1d.o globals.o PrintUtils.o LinearAlgebra.o gmsh_io.o MPI_OMP.o Communications.o
+inout.o : inout.F $(BUILD_PROVENANCE_OBJECT) HDF5_io.o flux_surface_transport_data.o transport_models_1d.o globals.o PrintUtils.o LinearAlgebra.o gmsh_io.o MPI_OMP.o Communications.o magnetic_geometry_state.o magnetic_topology.o
 	$(FC) -c $(FCFLAGS) $(INC)  $< -o $@
 
 Debug.F : $(SDIR)/Utils/Debug.f90
@@ -419,14 +429,14 @@ Convergence.F : $(SDIR)/Convergence.f90
 Convergence.o : Convergence.F inout.o gmsh_io.o reference_element.o MPI_OMP.o PrintUtils.o Debug.o initialization.o Postprocess.o
 	$(FC) -c $(FCFLAGS) $(INC)  $< -o $@
 
-MHDG-$(MDL)-$(MODE)-$(DIM) : Main_utils.o MPI_OMP.o matrices_types.o interpolation.o magnetic_topology.o PrintUtils.o prec_const.o types.o globals.o adimensionalization.o Debug.o LinearAlgebra.o magnetic_field.o external_heating.o $(IMPURITY_RADIATION_OBJECT) physics.o read_input.o HDF5_io.o $(BUILD_PROVENANCE_OBJECT) flux_surface_transport_data.o transport_models_1d_config.o transport_models_1d_derived.o transport_models_1d.o transport_models_1d_update.o transport_models_1d_diffusion_bohm_gyrobohm.o transport_models_1d_common.o transport_models_1d_pinch.o transport_models_1d_io.o transport_models_1d_runtime.o inout.o gmsh_io.o gmsh.o reference_element.o preprocess.o analytical.o initialization.o element_mapping.o adaptivity_projection.o hdg_PrecalculatedFirstEquation.o hdg_ComputeJacobian.o  $(ADDMOD) hdg_Mapping.o hdg_BC.o hdg_Assembly.o solve_global_system.o compute_element_solution.o adaptivity_general.o adaptivity_common.o mod_splines.o adaptivity_estimator.o adaptivity_indicator.o  domain_decomposition.o MHDG.o
-	$(FC) $(FCFLAGS)  Main_utils.o MPI_OMP.o matrices_types.o interpolation.o magnetic_topology.o PrintUtils.o prec_const.o types.o globals.o adimensionalization.o Debug.o LinearAlgebra.o magnetic_field.o external_heating.o $(IMPURITY_RADIATION_OBJECT) physics.o read_input.o HDF5_io.o $(BUILD_PROVENANCE_OBJECT) flux_surface_transport_data.o transport_models_1d_config.o transport_models_1d_derived.o transport_models_1d.o transport_models_1d_update.o transport_models_1d_diffusion_bohm_gyrobohm.o transport_models_1d_common.o transport_models_1d_pinch.o transport_models_1d_io.o transport_models_1d_runtime.o inout.o gmsh_io.o gmsh.o reference_element.o preprocess.o analytical.o initialization.o element_mapping.o adaptivity_projection.o hdg_PrecalculatedFirstEquation.o hdg_ComputeJacobian.o  Postprocess.o $(ADDMOD) hdg_Mapping.o hdg_BC.o hdg_Assembly.o  solve_global_system.o compute_element_solution.o mod_splines.o adaptivity_general.o adaptivity_common.o adaptivity_indicator.o adaptivity_estimator.o domain_decomposition.o MHDG.o -o MHDG-$(MDL)-$(MODE)-$(DIM) $(LIB)
+MHDG-$(MDL)-$(MODE)-$(DIM) : Main_utils.o MPI_OMP.o matrices_types.o interpolation.o magnetic_topology.o magnetic_geometry_state.o PrintUtils.o prec_const.o types.o globals.o adimensionalization.o Debug.o LinearAlgebra.o magnetic_field.o external_heating.o $(IMPURITY_RADIATION_OBJECT) physics.o read_input.o HDF5_io.o $(BUILD_PROVENANCE_OBJECT) flux_surface_transport_data.o transport_models_1d_config.o transport_models_1d_derived.o transport_models_1d.o transport_models_1d_update.o transport_models_1d_diffusion_bohm_gyrobohm.o transport_models_1d_common.o transport_models_1d_pinch.o transport_models_1d_io.o transport_models_1d_runtime.o inout.o gmsh_io.o gmsh.o reference_element.o preprocess.o analytical.o initialization.o element_mapping.o adaptivity_projection.o hdg_PrecalculatedFirstEquation.o hdg_ComputeJacobian.o  $(ADDMOD) hdg_Mapping.o hdg_BC.o hdg_Assembly.o solve_global_system.o compute_element_solution.o adaptivity_general.o adaptivity_common.o mod_splines.o adaptivity_estimator.o adaptivity_indicator.o  domain_decomposition.o MHDG.o
+	$(FC) $(FCFLAGS)  Main_utils.o MPI_OMP.o matrices_types.o interpolation.o magnetic_topology.o magnetic_geometry_state.o PrintUtils.o prec_const.o types.o globals.o adimensionalization.o Debug.o LinearAlgebra.o magnetic_field.o external_heating.o $(IMPURITY_RADIATION_OBJECT) physics.o read_input.o HDF5_io.o $(BUILD_PROVENANCE_OBJECT) flux_surface_transport_data.o transport_models_1d_config.o transport_models_1d_derived.o transport_models_1d.o transport_models_1d_update.o transport_models_1d_diffusion_bohm_gyrobohm.o transport_models_1d_common.o transport_models_1d_pinch.o transport_models_1d_io.o transport_models_1d_runtime.o inout.o gmsh_io.o gmsh.o reference_element.o preprocess.o analytical.o initialization.o element_mapping.o adaptivity_projection.o hdg_PrecalculatedFirstEquation.o hdg_ComputeJacobian.o  Postprocess.o $(ADDMOD) hdg_Mapping.o hdg_BC.o hdg_Assembly.o  solve_global_system.o compute_element_solution.o mod_splines.o adaptivity_general.o adaptivity_common.o adaptivity_indicator.o adaptivity_estimator.o domain_decomposition.o MHDG.o -o MHDG-$(MDL)-$(MODE)-$(DIM) $(LIB)
 	/bin/cp -f MHDG-$(MDL)-$(MODE)-$(DIM) ../test/
 #	/bin/cp -f MHDG-$(MDL)-$(MODE)-$(DIM) ../test_anal/
 #	/bin/cp -f MHDG-$(MDL)-$(MODE)-$(DIM) ../test_psblas/
 
-Convergence-$(MDL)-$(DIM) : MPI_OMP.o matrices_types.o interpolation.o magnetic_topology.o PrintUtils.o prec_const.o types.o globals.o adimensionalization.o Debug.o LinearAlgebra.o magnetic_field.o external_heating.o $(IMPURITY_RADIATION_OBJECT) physics.o read_input.o HDF5_io.o $(BUILD_PROVENANCE_OBJECT) flux_surface_transport_data.o transport_models_1d_config.o transport_models_1d_derived.o transport_models_1d.o transport_models_1d_update.o transport_models_1d_diffusion_bohm_gyrobohm.o transport_models_1d_common.o transport_models_1d_pinch.o transport_models_1d_io.o transport_models_1d_runtime.o inout.o gmsh_io.o gmsh.o reference_element.o preprocess.o analytical.o initialization.o hdg_PrecalculatedFirstEquation.o hdg_ComputeJacobian.o  $(ADDMOD) hdg_Mapping.o hdg_BC.o hdg_Assembly.o solve_global_system.o compute_element_solution.o adaptivity_general.o adaptivity_common.o  mod_splines.o Convergence.o
-	$(FC) $(FCFLAGS) $(OBJS) MPI_OMP.o matrices_types.o interpolation.o magnetic_topology.o PrintUtils.o prec_const.o types.o globals.o adimensionalization.o Debug.o LinearAlgebra.o magnetic_field.o external_heating.o $(IMPURITY_RADIATION_OBJECT) physics.o read_input.o HDF5_io.o $(BUILD_PROVENANCE_OBJECT) flux_surface_transport_data.o transport_models_1d_config.o transport_models_1d_derived.o transport_models_1d.o transport_models_1d_update.o transport_models_1d_diffusion_bohm_gyrobohm.o transport_models_1d_common.o transport_models_1d_pinch.o transport_models_1d_io.o transport_models_1d_runtime.o inout.o gmsh_io.o gmsh.o reference_element.o preprocess.o analytical.o initialization.o hdg_PrecalculatedFirstEquation.o hdg_ComputeJacobian.o  Postprocess.o $(ADDMOD) hdg_Mapping.o hdg_BC.o hdg_Assembly.o  solve_global_system.o compute_element_solution.o adaptivity_general.o adaptivity_common.o mod_splines.o Convergence.o -o Convergence-$(MDL)-$(MODE)-$(DIM) $(LIB)
+Convergence-$(MDL)-$(DIM) : MPI_OMP.o matrices_types.o interpolation.o magnetic_topology.o magnetic_geometry_state.o PrintUtils.o prec_const.o types.o globals.o adimensionalization.o Debug.o LinearAlgebra.o magnetic_field.o external_heating.o $(IMPURITY_RADIATION_OBJECT) physics.o read_input.o HDF5_io.o $(BUILD_PROVENANCE_OBJECT) flux_surface_transport_data.o transport_models_1d_config.o transport_models_1d_derived.o transport_models_1d.o transport_models_1d_update.o transport_models_1d_diffusion_bohm_gyrobohm.o transport_models_1d_common.o transport_models_1d_pinch.o transport_models_1d_io.o transport_models_1d_runtime.o inout.o gmsh_io.o gmsh.o reference_element.o preprocess.o analytical.o initialization.o hdg_PrecalculatedFirstEquation.o hdg_ComputeJacobian.o  $(ADDMOD) hdg_Mapping.o hdg_BC.o hdg_Assembly.o solve_global_system.o compute_element_solution.o adaptivity_general.o adaptivity_common.o  mod_splines.o Convergence.o
+	$(FC) $(FCFLAGS) $(OBJS) MPI_OMP.o matrices_types.o interpolation.o magnetic_topology.o magnetic_geometry_state.o PrintUtils.o prec_const.o types.o globals.o adimensionalization.o Debug.o LinearAlgebra.o magnetic_field.o external_heating.o $(IMPURITY_RADIATION_OBJECT) physics.o read_input.o HDF5_io.o $(BUILD_PROVENANCE_OBJECT) flux_surface_transport_data.o transport_models_1d_config.o transport_models_1d_derived.o transport_models_1d.o transport_models_1d_update.o transport_models_1d_diffusion_bohm_gyrobohm.o transport_models_1d_common.o transport_models_1d_pinch.o transport_models_1d_io.o transport_models_1d_runtime.o inout.o gmsh_io.o gmsh.o reference_element.o preprocess.o analytical.o initialization.o hdg_PrecalculatedFirstEquation.o hdg_ComputeJacobian.o  Postprocess.o $(ADDMOD) hdg_Mapping.o hdg_BC.o hdg_Assembly.o  solve_global_system.o compute_element_solution.o adaptivity_general.o adaptivity_common.o mod_splines.o Convergence.o -o Convergence-$(MDL)-$(MODE)-$(DIM) $(LIB)
 	/bin/cp -f Convergence-$(MDL)-$(MODE)-$(DIM) ../test/
 #	/bin/cp -f Convergence-$(MDL)-$(MODE)-$(DIM) ../test_anal/
 

--- a/regression_tests/README.md
+++ b/regression_tests/README.md
@@ -198,7 +198,8 @@ regression_tests/regression.sh suite compare \
 ### Publish accepted references
 
 For a complete refresh, one command starts or continues the persisted golden
-campaign, stops at each required review gate, and publishes after final checks:
+campaign and runs every producer and verification stage. It stops once, after
+the complete candidate is ready for review:
 
 ```bash
 regression_tests/regression.sh golden update legacy_case \
@@ -206,8 +207,9 @@ regression_tests/regression.sh golden update legacy_case \
   --output /private/path/new_golden_bundle --bundle-version 2.5.0
 ```
 
-Run the same command again with `--accept STAGE` after reviewing a reported
-gate. `golden status WORKSPACE` shows progress; without `--workspace`, the
+Run the same command again with `--accept campaign` after reviewing the final
+candidate. This second command only publishes; it does not rerun completed
+stages. `golden status WORKSPACE` shows progress; without `--workspace`, the
 workspace is `MHDG_REGRESSION_RUN_ROOT/golden_campaigns/RUN_ID`. Resumes reject
 changed inputs and never overwrite a workspace, candidate, or output.
 
@@ -267,29 +269,29 @@ regression_tests/regression.sh golden update diverted_case \
   --workspace /private/path/campaigns/pr03-diverted-refresh-01 \
   --output /private/path/golden_bundles/diverted_case_pr03_golden \
   --bundle-version 1.0.0-pr03-golden.1 \
+  --bootstrap-candidate \
   --build-jobs 8
 ```
 
-The first invocation runs only the full adaptive `mpi4_omp4` cold producer and
-stops at `cold_adaptive_reference`. Its accepted final output is mapped to both
-`warm_restart` and `warm_reference`; workflow `outputs` declare these as
-publishable roles without making them cold-run inputs. Inspect status and then
-accept the gate with the otherwise identical update command:
+The first invocation runs the full adaptive `mpi4_omp4` cold producer, maps its
+final output to `warm_restart` and `warm_reference`, generates a reconverged
+warm reference, runs the warm-layout and race checks, and finishes with final
+warm verification. It then stops at `awaiting_acceptance` without publishing.
+Inspect status and the reports below the workspace, then repeat the identical
+update command with `--accept campaign`:
 
 ```bash
 regression_tests/regression.sh golden status \
   /private/path/campaigns/pr03-diverted-refresh-01
 
 # Add this to the identical `golden update` command:
---accept cold_adaptive_reference
+--accept campaign
 ```
 
-That continuation generates a reconverged warm reference and stops at
-`warm_reference`. After reviewing it, continue with `--accept warm_reference`.
-The campaign then runs all-layout warm checks, the diverted two-step race
-matrix, final warm verification, and atomically publishes the golden bundle.
 If a run is interrupted, repeat the identical command without `--accept`; the
-recorded stage resumes. Never delete or reuse the workspace or output path.
+recorded stage resumes. `--bootstrap-candidate` is only for the first diverted
+promotion; future refreshes start from the accepted golden and omit it. Never
+delete or reuse the workspace or output path.
 
 Refresh the limited golden with the same lifecycle but `legacy_case`, an
 accepted golden source settings file, and distinct run/workspace/output names:
@@ -304,8 +306,10 @@ regression_tests/regression.sh golden update legacy_case \
   --build-jobs 8
 ```
 
-It pauses at `cold_matrix`, `warm_reference`, and `impurity_references`; review
-and accept each reported gate with the identical command plus `--accept ID`.
+It runs through the cold matrix, warm reference, impurity references, smoke and
+race checks, and final verification in one invocation. Review the composed
+candidate once, then publish it with the identical command plus
+`--accept campaign`.
 
 The `legacy_case` order was checked against the accepted PR 02 record: clean
 builds at `7ce486f`, its full cold-matrix refresh, the passing disabled

--- a/regression_tests/README.md
+++ b/regression_tests/README.md
@@ -293,6 +293,11 @@ recorded stage resumes. `--bootstrap-candidate` is only for the first diverted
 promotion; future refreshes start from the accepted golden and omit it. Never
 delete or reuse the workspace or output path.
 
+If a stage records a failure, correct its tracked workflow or source bundle,
+then repeat the identical command with `--retry-failed`. The failed attempt is
+retained in campaign provenance and the corrected stage receives a distinct
+`-retry-N` run ID. Completed producer stages are not rerun.
+
 Refresh the limited golden with the same lifecycle but `legacy_case`, an
 accepted golden source settings file, and distinct run/workspace/output names:
 

--- a/regression_tests/README.md
+++ b/regression_tests/README.md
@@ -303,6 +303,12 @@ If the correction affects an earlier campaign declaration, use
 restores the preceding candidate, archives superseded downstream attempts, and
 uses distinct run, candidate, report, and settings paths for the replacements.
 
+Because multiple cases share the campaign catalog, a change confined to another
+case does not invalidate an in-progress campaign. Resume records the old and new
+catalog identities in `campaign_catalog_refreshes` after confirming that the
+selected case declaration is unchanged. A change to the selected case still
+requires an explicit `--retry-from STAGE`.
+
 Refresh the limited golden with the same lifecycle but `legacy_case`, an
 accepted golden source settings file, and distinct run/workspace/output names:
 

--- a/regression_tests/README.md
+++ b/regression_tests/README.md
@@ -100,6 +100,11 @@ ranks, and threads. MPI runs bind each rank to exclusive cores.
 | `warm_parallelism` | `warm`, all layouts | Periodic layout characterization. |
 | `race_matrix` | Both one-step workflows, every pair of tracked layouts | Periodic race check. |
 | `cold_matrix` | Both full cold workflows, all layouts and all layout pairs | Overnight golden and reproducibility evidence. |
+| `stored_field_compatibility` | Limited two-Newton-step scratch start, stored `Br/Bz` | Compatibility smoke for `compute_from_flux=false`. |
+| `diverted_warm` | Diverted warm restart, `mpi4_omp4` | Routine diverted topology/transport check. |
+| `diverted_warm_parallelism` | Diverted warm restart, all layouts | Diverted layout characterization. |
+| `diverted_cold_adaptive` | Full diverted adaptive cold start, `mpi4_omp4` | Canonical diverted reference producer. |
+| `diverted_race_matrix` | Diverted two-step fixed/adaptive starts, every layout pair | Lightweight diverted race and cache-refresh evidence. |
 
 Warm and race suites are short. Full cold workflows are longer, and
 `cold_matrix` can take hours. Runtime is recorded but is not a pass criterion.
@@ -207,7 +212,8 @@ workspace is `MHDG_REGRESSION_RUN_ROOT/golden_campaigns/RUN_ID`. Resumes reject
 changed inputs and never overwrite a workspace, candidate, or output.
 
 The default refresh includes cold matrices, warm and mixture references,
-initialization/race evidence, and final warm/mixture verification. Repeat
+initialization/stored-field/race evidence, warm layout checks, and final
+warm/mixture verification. Repeat
 `--only` to select `cold_matrix`, `warm`, or `impurity_mixture`. A cold-matrix
 refresh also updates the canonical warm restart, while `warm` updates the warm
 reference. Updating only warm or only mixture references records a consistency
@@ -216,6 +222,90 @@ warning; select both together to avoid it.
 The verified candidate is published atomically as a golden bundle. Campaign
 state, declaration, build metadata, suite summaries, run plans/metadata, and
 comparison reports are registered below `provenance/golden_campaign/`.
+
+### PR03 limited and diverted refresh
+
+PR03 keeps the exhaustive limited campaign and adds an independent diverted
+campaign. Run them sequentially: each campaign performs clean serial and MPI
+builds in the same worktree.
+
+The limited source remains the last accepted `legacy_case` golden bundle. Its
+full campaign runs the fixed/adaptive cold layout matrix, impurity references,
+the stored-field compatibility smoke, warm layouts, the two-step race matrix,
+and final verification. The tracked workflows render `compute_from_flux=true`;
+the compatibility smoke alone renders it false.
+
+The first diverted source is a candidate bundle, because no diverted golden
+exists yet. Prepare the filenames declared by `cases/diverted_case.json`. All
+transport namelists used by the cold and warm workflows must contain:
+
+```text
+transport_region_policy = 'core_and_main_sol'
+c_bohm_n_rho_slope = 0.7
+```
+
+Use `puff = 5.0e21` in every staged parameter file and
+`diff_n_min_phys = 0.1` in the final continuation and warm transport files.
+The case workflows explicitly render `compute_from_flux=true`, even if a
+prepared parameter file still contains false. Create the source candidate:
+
+```bash
+regression_tests/regression.sh bundle create \
+  --case diverted_case \
+  --source /private/path/prepared_diverted_case \
+  --output /private/path/diverted_case_pr03_source \
+  --bundle-version pr03-source.1
+```
+
+Point a private settings file at that candidate and start the resumable cold
+overnight in `tmux` or another persistent shell:
+
+```bash
+regression_tests/regression.sh golden update diverted_case \
+  --settings /private/path/diverted-source.env \
+  --run-id pr03-diverted-refresh-01 \
+  --workspace /private/path/campaigns/pr03-diverted-refresh-01 \
+  --output /private/path/golden_bundles/diverted_case_pr03_golden \
+  --bundle-version 1.0.0-pr03-golden.1 \
+  --build-jobs 8
+```
+
+The first invocation runs only the full adaptive `mpi4_omp4` cold producer and
+stops at `cold_adaptive_reference`. Its accepted final output is mapped to both
+`warm_restart` and `warm_reference`; workflow `outputs` declare these as
+publishable roles without making them cold-run inputs. Inspect status and then
+accept the gate with the otherwise identical update command:
+
+```bash
+regression_tests/regression.sh golden status \
+  /private/path/campaigns/pr03-diverted-refresh-01
+
+# Add this to the identical `golden update` command:
+--accept cold_adaptive_reference
+```
+
+That continuation generates a reconverged warm reference and stops at
+`warm_reference`. After reviewing it, continue with `--accept warm_reference`.
+The campaign then runs all-layout warm checks, the diverted two-step race
+matrix, final warm verification, and atomically publishes the golden bundle.
+If a run is interrupted, repeat the identical command without `--accept`; the
+recorded stage resumes. Never delete or reuse the workspace or output path.
+
+Refresh the limited golden with the same lifecycle but `legacy_case`, an
+accepted golden source settings file, and distinct run/workspace/output names:
+
+```bash
+regression_tests/regression.sh golden update legacy_case \
+  --settings /private/path/limited-golden-source.env \
+  --run-id pr03-limited-refresh-01 \
+  --workspace /private/path/campaigns/pr03-limited-refresh-01 \
+  --output /private/path/golden_bundles/legacy_case_pr03_golden \
+  --bundle-version 2.5.0-pr03-golden.1 \
+  --build-jobs 8
+```
+
+It pauses at `cold_matrix`, `warm_reference`, and `impurity_references`; review
+and accept each reported gate with the identical command plus `--accept ID`.
 
 The `legacy_case` order was checked against the accepted PR 02 record: clean
 builds at `7ce486f`, its full cold-matrix refresh, the passing disabled

--- a/regression_tests/README.md
+++ b/regression_tests/README.md
@@ -298,6 +298,11 @@ then repeat the identical command with `--retry-failed`. The failed attempt is
 retained in campaign provenance and the corrected stage receives a distinct
 `-retry-N` run ID. Completed producer stages are not rerun.
 
+If the correction affects an earlier campaign declaration, use
+`--retry-from STAGE` instead. The campaign records the declaration amendment,
+restores the preceding candidate, archives superseded downstream attempts, and
+uses distinct run, candidate, report, and settings paths for the replacements.
+
 Refresh the limited golden with the same lifecycle but `legacy_case`, an
 accepted golden source settings file, and distinct run/workspace/output names:
 

--- a/regression_tests/cases/diverted_case.json
+++ b/regression_tests/cases/diverted_case.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 2,
-  "description": "Routine legacy regression case",
+  "description": "Lower-single-null transport regression case",
   "reference": {
     "branch": "develop",
-    "revision": "29f442db67bac169b2616f2cbe399289d137993c"
+    "revision": "db468f73f899457bf9104055e953cf2465532750"
   },
   "files": {
     "required": {
@@ -18,14 +18,6 @@
     "optional": {
       "warm_restart": "restart.h5",
       "warm_reference": "reference_mpi4_omp4.h5",
-      "warm_impurity_off_restart": "restart_impurity_off.h5",
-      "warm_impurity_off_reference": "reference_impurity_off_mpi4_omp4.h5",
-      "warm_impurity_n_restart": "restart_impurity_n.h5",
-      "warm_impurity_n_reference": "reference_impurity_n_mpi4_omp4.h5",
-      "impurity_n_configuration": "impurity_model_n.nml",
-      "warm_impurity_nw_restart": "restart_impurity_nw.h5",
-      "warm_impurity_nw_reference": "reference_impurity_nw_mpi4_omp4.h5",
-      "impurity_nw_configuration": "impurity_model_nw.nml",
       "coarse_mesh": "mesh_adaptive_initial.msh",
       "cold_fixed_time_init_parameters": "param_cold_fixed_time_init.txt",
       "cold_fixed_diffusion_reduction_parameters": "param_cold_fixed_diffusion_reduction.txt",
@@ -45,7 +37,7 @@
   "workflows": {
     "warm": {
       "type": "warm_same_state",
-      "description": "Reconverge an unchanged steady restart on the fixed mesh",
+      "description": "Reconverge the accepted diverted state on the fixed mesh",
       "inputs": [
         "mesh",
         "geometry",
@@ -67,38 +59,9 @@
         "compute_from_flux": true
       }
     },
-    "warm_impurity_off": {
-      "extends": "warm",
-      "description": "Reconverge the accepted state with impurity radiation disabled",
-      "restart": "warm_impurity_off_restart",
-      "reference": "warm_impurity_off_reference",
-      "parameter_overrides": {
-        "impurity_radiation": false
-      }
-    },
-    "warm_impurity_n": {
-      "extends": "warm",
-      "description": "Reconverge the accepted state with single-nitrogen radiation",
-      "restart": "warm_impurity_n_restart",
-      "reference": "warm_impurity_n_reference",
-      "impurity_configuration": "impurity_n_configuration",
-      "parameter_overrides": {
-        "impurity_radiation": true
-      }
-    },
-    "warm_impurity_nw": {
-      "extends": "warm",
-      "description": "Reconverge the accepted state with nitrogen-tungsten radiation",
-      "restart": "warm_impurity_nw_restart",
-      "reference": "warm_impurity_nw_reference",
-      "impurity_configuration": "impurity_nw_configuration",
-      "parameter_overrides": {
-        "impurity_radiation": true
-      }
-    },
     "cold_fixed": {
       "type": "staged_fixed_mesh",
-      "description": "Reach the canonical state from analytical initialization on the fixed mesh",
+      "description": "Reach the diverted state from analytical initialization on the fixed mesh",
       "inputs": [
         "geometry",
         "equilibrium_magnetic_field",
@@ -106,7 +69,7 @@
       ],
       "impurity_configuration": "impurity_configuration",
       "mesh": "mesh",
-      "reference": "warm_reference",
+      "outputs": ["warm_restart", "warm_reference"],
       "layout": "mpi4_omp4",
       "comparison": {
         "method": "fixed_hdf5",
@@ -160,7 +123,7 @@
     "cold_adaptive": {
       "extends": "cold_fixed",
       "type": "staged_adaptive_mesh",
-      "description": "Repeat the cold workflow with early-stage mesh adaptation",
+      "description": "Generate the canonical diverted state with early-stage mesh adaptation",
       "mesh": "coarse_mesh",
       "comparison": {
         "method": "mesh_independent",
@@ -174,12 +137,13 @@
     },
     "cold_step_fixed": {
       "type": "staged_fixed_mesh",
-      "description": "Run two Newton iterations on the coarse mesh without adaptation",
+      "description": "Run two diverted Newton iterations without adaptation",
       "inputs": [
         "geometry",
         "equilibrium_magnetic_field",
         "equilibrium_current_density"
       ],
+      "impurity_configuration": "impurity_configuration",
       "mesh": "coarse_mesh",
       "layout": "serial_omp1",
       "comparison": {
@@ -211,30 +175,14 @@
         }
       ]
     },
-    "cold_step_impurity_off": {
-      "extends": "cold_step_fixed",
-      "description": "Exercise analytical initialization with impurity radiation disabled",
-      "parameter_overrides": {
-        "impurity_radiation": false
-      }
-    },
-    "cold_step_stored_field": {
-      "extends": "cold_step_fixed",
-      "description": "Exercise the explicit stored-field compatibility path",
-      "parameter_overrides": {
-        "compute_from_flux": false
-      }
-    },
     "cold_step_adaptive": {
       "extends": "cold_step_fixed",
       "type": "staged_adaptive_mesh",
-      "description": "Run two Newton iterations with one coarse-mesh adaptation pass",
+      "description": "Run two diverted Newton iterations with one adaptation pass",
       "parameter_overrides": {
         "adaptivity": true
       },
-      "adaptive_stages": [
-        "single_step"
-      ]
+      "adaptive_stages": ["single_step"]
     }
   }
 }

--- a/regression_tests/cases/legacy_case.json
+++ b/regression_tests/cases/legacy_case.json
@@ -181,6 +181,7 @@
         "equilibrium_current_density"
       ],
       "mesh": "coarse_mesh",
+      "impurity_configuration": "impurity_configuration",
       "layout": "serial_omp1",
       "comparison": {
         "method": "fixed_hdf5",

--- a/regression_tests/golden_campaigns.json
+++ b/regression_tests/golden_campaigns.json
@@ -57,24 +57,15 @@
           "role_mappings": [
             {
               "workflow": "warm_impurity_off",
-              "roles": [
-                "warm_impurity_off_restart",
-                "warm_impurity_off_reference"
-              ]
+              "roles": ["warm_impurity_off_reference"]
             },
             {
               "workflow": "warm_impurity_n",
-              "roles": [
-                "warm_impurity_n_restart",
-                "warm_impurity_n_reference"
-              ]
+              "roles": ["warm_impurity_n_reference"]
             },
             {
               "workflow": "warm_impurity_nw",
-              "roles": [
-                "warm_impurity_nw_restart",
-                "warm_impurity_nw_reference"
-              ]
+              "roles": ["warm_impurity_nw_reference"]
             }
           ]
         },

--- a/regression_tests/golden_campaigns.json
+++ b/regression_tests/golden_campaigns.json
@@ -85,9 +85,21 @@
           "acceptance_required": false
         },
         {
+          "id": "stored_field_compatibility",
+          "kind": "suite",
+          "suite": "stored_field_compatibility",
+          "acceptance_required": false
+        },
+        {
+          "id": "warm_parallelism",
+          "kind": "suite",
+          "suite": "warm_parallelism",
+          "acceptance_required": false
+        },
+        {
           "id": "race_evidence",
           "kind": "suite",
-          "suite": "race",
+          "suite": "race_matrix",
           "acceptance_required": false
         },
         {
@@ -100,6 +112,59 @@
           "id": "verify_impurity_mixture",
           "kind": "verification",
           "suite": "impurity_mixture",
+          "acceptance_required": false
+        }
+      ]
+    },
+    "diverted_case": {
+      "case": "diverted_case",
+      "source_bundle_class": "candidate",
+      "update_together": [
+        ["cold_adaptive", "warm"]
+      ],
+      "stages": [
+        {
+          "id": "cold_adaptive_reference",
+          "kind": "reference",
+          "suite": "diverted_cold_adaptive",
+          "component": "cold_adaptive",
+          "acceptance_required": true,
+          "role_mappings": [
+            {
+              "workflow": "cold_adaptive",
+              "roles": ["warm_restart", "warm_reference"]
+            }
+          ]
+        },
+        {
+          "id": "warm_reference",
+          "kind": "reference",
+          "suite": "diverted_warm",
+          "component": "warm",
+          "acceptance_required": true,
+          "role_mappings": [
+            {
+              "workflow": "warm",
+              "roles": ["warm_reference"]
+            }
+          ]
+        },
+        {
+          "id": "warm_parallelism",
+          "kind": "suite",
+          "suite": "diverted_warm_parallelism",
+          "acceptance_required": false
+        },
+        {
+          "id": "race_evidence",
+          "kind": "suite",
+          "suite": "diverted_race_matrix",
+          "acceptance_required": false
+        },
+        {
+          "id": "verify_warm",
+          "kind": "verification",
+          "suite": "diverted_warm",
           "acceptance_required": false
         }
       ]

--- a/regression_tests/golden_campaigns.json
+++ b/regression_tests/golden_campaigns.json
@@ -118,7 +118,6 @@
     },
     "diverted_case": {
       "case": "diverted_case",
-      "source_bundle_class": "candidate",
       "update_together": [
         ["cold_adaptive", "warm"]
       ],

--- a/regression_tests/regression.sh
+++ b/regression_tests/regression.sh
@@ -19,7 +19,7 @@ Usage:
   regression_tests/regression.sh suite run SUITE --settings FILE [--run-only] [--resume]
   regression_tests/regression.sh suite compare SUITE_SUMMARY
   regression_tests/regression.sh suite check [SUITE] [--settings FILE] [--build]
-  regression_tests/regression.sh golden update CASE --settings FILE --run-id ID --output DIR --bundle-version VERSION [--only COMPONENT] [--bootstrap-candidate] [--retry-failed]
+  regression_tests/regression.sh golden update CASE --settings FILE --run-id ID --output DIR --bundle-version VERSION [--only COMPONENT] [--bootstrap-candidate] [--retry-failed | --retry-from STAGE]
   regression_tests/regression.sh golden status WORKSPACE
 
 Commands:

--- a/regression_tests/regression.sh
+++ b/regression_tests/regression.sh
@@ -37,8 +37,10 @@ Commands:
   golden status    Show persisted golden-update state.
 
 Suites: warm, impurity_scalar_baseline, impurity_mixture, impurity_references,
-        initialization_smoke, race, cold,
-        warm_parallelism, race_matrix, cold_matrix.
+        initialization_smoke, stored_field_compatibility, race, cold,
+        warm_parallelism, race_matrix, cold_matrix, diverted_warm,
+        diverted_warm_parallelism, diverted_cold_adaptive,
+        diverted_race_matrix.
 EOF
 }
 

--- a/regression_tests/regression.sh
+++ b/regression_tests/regression.sh
@@ -19,7 +19,7 @@ Usage:
   regression_tests/regression.sh suite run SUITE --settings FILE [--run-only] [--resume]
   regression_tests/regression.sh suite compare SUITE_SUMMARY
   regression_tests/regression.sh suite check [SUITE] [--settings FILE] [--build]
-  regression_tests/regression.sh golden update CASE --settings FILE --run-id ID --output DIR --bundle-version VERSION [--only COMPONENT] [--bootstrap-candidate]
+  regression_tests/regression.sh golden update CASE --settings FILE --run-id ID --output DIR --bundle-version VERSION [--only COMPONENT] [--bootstrap-candidate] [--retry-failed]
   regression_tests/regression.sh golden status WORKSPACE
 
 Commands:

--- a/regression_tests/regression.sh
+++ b/regression_tests/regression.sh
@@ -19,7 +19,7 @@ Usage:
   regression_tests/regression.sh suite run SUITE --settings FILE [--run-only] [--resume]
   regression_tests/regression.sh suite compare SUITE_SUMMARY
   regression_tests/regression.sh suite check [SUITE] [--settings FILE] [--build]
-  regression_tests/regression.sh golden update CASE --settings FILE --run-id ID --output DIR --bundle-version VERSION [--only COMPONENT]
+  regression_tests/regression.sh golden update CASE --settings FILE --run-id ID --output DIR --bundle-version VERSION [--only COMPONENT] [--bootstrap-candidate]
   regression_tests/regression.sh golden status WORKSPACE
 
 Commands:

--- a/regression_tests/schemas/case.schema.json
+++ b/regression_tests/schemas/case.schema.json
@@ -124,6 +124,9 @@
         "reference": {
           "$ref": "#/$defs/identifier"
         },
+        "outputs": {
+          "$ref": "#/$defs/identifier_list"
+        },
         "impurity_configuration": {
           "$ref": "#/$defs/identifier"
         },

--- a/regression_tests/schemas/golden-campaigns.schema.json
+++ b/regression_tests/schemas/golden-campaigns.schema.json
@@ -25,7 +25,6 @@
       "required": ["case", "stages"],
       "properties": {
         "case": {"$ref": "#/$defs/identifier"},
-        "source_bundle_class": {"enum": ["candidate", "golden"]},
         "update_together": {
           "type": "array",
           "items": {

--- a/regression_tests/schemas/golden-campaigns.schema.json
+++ b/regression_tests/schemas/golden-campaigns.schema.json
@@ -25,6 +25,7 @@
       "required": ["case", "stages"],
       "properties": {
         "case": {"$ref": "#/$defs/identifier"},
+        "source_bundle_class": {"enum": ["candidate", "golden"]},
         "update_together": {
           "type": "array",
           "items": {

--- a/regression_tests/suites.json
+++ b/regression_tests/suites.json
@@ -41,6 +41,13 @@
       "layouts": ["mpi4_omp4"],
       "reference_comparisons": false
     },
+    "stored_field_compatibility": {
+      "description": "One-step limited compatibility check using stored Br and Bz",
+      "case": "legacy_case",
+      "workflows": ["cold_step_stored_field"],
+      "layouts": ["serial_omp1"],
+      "reference_comparisons": false
+    },
     "warm_parallelism": {
       "description": "Warm restart across serial, MPI, and OpenMP layouts",
       "case": "legacy_case",
@@ -107,6 +114,62 @@
     "race_matrix": {
       "description": "All-pairs one-step race checks on the coarse mesh",
       "case": "legacy_case",
+      "workflows": ["cold_step_fixed", "cold_step_adaptive"],
+      "layout_comparisons": [
+        {
+          "baseline": "serial_omp1",
+          "candidate": "serial_omp16"
+        },
+        {
+          "baseline": "serial_omp1",
+          "candidate": "mpi4_omp1"
+        },
+        {
+          "baseline": "serial_omp1",
+          "candidate": "mpi4_omp4"
+        },
+        {
+          "baseline": "serial_omp16",
+          "candidate": "mpi4_omp1"
+        },
+        {
+          "baseline": "serial_omp16",
+          "candidate": "mpi4_omp4"
+        },
+        {
+          "baseline": "mpi4_omp1",
+          "candidate": "mpi4_omp4"
+        }
+      ],
+      "tolerance_profile": "race_step"
+    },
+    "diverted_warm": {
+      "description": "Canonical diverted warm restart",
+      "case": "diverted_case",
+      "workflows": ["warm"],
+      "layouts": ["mpi4_omp4"]
+    },
+    "diverted_warm_parallelism": {
+      "description": "Diverted warm restart across all tracked layouts",
+      "case": "diverted_case",
+      "workflows": ["warm"],
+      "layouts": [
+        "serial_omp1",
+        "serial_omp16",
+        "mpi4_omp1",
+        "mpi4_omp4"
+      ]
+    },
+    "diverted_cold_adaptive": {
+      "description": "Full diverted adaptive cold start in the canonical layout",
+      "case": "diverted_case",
+      "workflows": ["cold_adaptive"],
+      "layouts": ["mpi4_omp4"],
+      "reference_comparisons": false
+    },
+    "diverted_race_matrix": {
+      "description": "Diverted fixed and adaptive two-Newton-step layout checks",
+      "case": "diverted_case",
       "workflows": ["cold_step_fixed", "cold_step_adaptive"],
       "layout_comparisons": [
         {

--- a/regression_tests/tests/fixtures/case_data.py
+++ b/regression_tests/tests/fixtures/case_data.py
@@ -11,6 +11,7 @@ PARAMETERS = """&INPUT_LST
     impurity_model_path = '/old/impurity_model.nml'
     field_path = '/old/equilibrium.h5'
     jtor_path = '/old/current_density.h5'
+    compute_from_flux = .false.
     save_folder = '/old/output/'
 /
 &SWITCH_LST

--- a/regression_tests/tests/test_bundles.py
+++ b/regression_tests/tests/test_bundles.py
@@ -97,6 +97,19 @@ class BundleWorkflowTests(unittest.TestCase):
         self.assertIn("warm_restart", required_case_roles(case, "warm"))
         self.assertEqual(summary.case_id, "legacy_case")
 
+    def test_workflow_outputs_are_not_runtime_inputs(self) -> None:
+        case = load_case_definition("diverted_case", REGRESSION_ROOT / "cases")
+        workflow = case["workflows"]["cold_adaptive"]
+
+        self.assertEqual(
+            workflow["output_roles"],
+            ["warm_restart", "warm_reference"],
+        )
+        self.assertNotIn(
+            "warm_restart",
+            required_case_roles(case, "cold_adaptive"),
+        )
+
     def test_creation_failures_do_not_replace_existing_data(self) -> None:
         (self.source / "geometry.geo").unlink()
         with self.assertRaisesRegex(BundleError, "required file missing.*geometry"):

--- a/regression_tests/tests/test_fixed_comparison.py
+++ b/regression_tests/tests/test_fixed_comparison.py
@@ -93,6 +93,70 @@ class Hdf5ComparisonTests(unittest.TestCase):
         self.assertEqual(report["status"], "failed")
         self.assertFalse(report["mesh"]["connectivity"]["T"]["passed"])
 
+    def test_magnetic_contract_matches(self) -> None:
+        self._write_magnetic(self.reference)
+        self._write_magnetic(self.candidate)
+
+        report = compare_hdf5_files(
+            self.reference, self.candidate, TOLERANCES
+        )
+
+        magnetic = report["magnetic"]
+        self.assertEqual(report["status"], "passed")
+        self.assertTrue(magnetic["present"])
+        self.assertTrue(magnetic["passed"])
+        self.assertEqual(magnetic["datasets"]["topology"]["mode"], "exact")
+        self.assertEqual(
+            magnetic["datasets"]["rho_pol_norm"]["relative_l2"],
+            0.0,
+        )
+
+    def test_magnetic_region_difference_fails(self) -> None:
+        self._write_magnetic(self.reference)
+        self._write_magnetic(self.candidate)
+        with h5py.File(self.candidate, "r+") as handle:
+            handle["magnetic/topology_region"][2] = 3
+
+        report = compare_hdf5_files(
+            self.reference, self.candidate, TOLERANCES
+        )
+
+        self.assertEqual(report["status"], "failed")
+        self.assertFalse(
+            report["magnetic"]["datasets"]["topology_region"]["passed"]
+        )
+        self.assertIn("magnetic/topology_region differs", report["failures"])
+
+    def test_missing_candidate_magnetic_contract_fails(self) -> None:
+        self._write_magnetic(self.reference)
+
+        report = compare_hdf5_files(
+            self.reference, self.candidate, TOLERANCES
+        )
+
+        self.assertEqual(report["status"], "failed")
+        self.assertIn("candidate is missing magnetic data", report["failures"])
+
+    @staticmethod
+    def _write_magnetic(path: Path) -> None:
+        with h5py.File(path, "r+") as handle:
+            magnetic = handle.create_group("magnetic")
+            magnetic.create_dataset("topology", data=np.asarray([b"limited"]))
+            magnetic.create_dataset("topology_id", data=np.asarray([1]))
+            magnetic.create_dataset(
+                "topology_region", data=np.asarray([1, 1, 2, 2])
+            )
+            magnetic.create_dataset(
+                "rho_pol_norm", data=np.asarray([0.0, 0.5, 1.0, 1.2])
+            )
+            magnetic.create_dataset(
+                "topology_normal",
+                data=np.asarray(
+                    [[1.0, 1.0, 1.0, 1.0], [0.0, 0.0, 0.0, 0.0]]
+                ),
+            )
+
+
 class CompareCommandTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary_directory = tempfile.TemporaryDirectory()

--- a/regression_tests/tests/test_golden_update.py
+++ b/regression_tests/tests/test_golden_update.py
@@ -102,7 +102,9 @@ class GoldenUpdateTests(unittest.TestCase):
                 "impurity_references",
                 "impurity_references",
                 "initialization_smoke",
-                "race",
+                "stored_field_compatibility",
+                "warm_parallelism",
+                "race_matrix",
                 "warm",
                 "impurity_mixture",
             ],
@@ -112,7 +114,7 @@ class GoldenUpdateTests(unittest.TestCase):
         calls = self.run_suite.call_args_list
         self.assertEqual(
             [call.args[7] for call in calls],
-            ["golden", *("candidate" for _ in range(7))],
+            ["golden", *("candidate" for _ in range(9))],
         )
         self.assertEqual(
             [Path(call.args[0]).name for call in calls[1:]],
@@ -120,10 +122,7 @@ class GoldenUpdateTests(unittest.TestCase):
                 "cold_matrix.env",
                 "warm_reference.env",
                 "impurity_restarts.env",
-                "impurity_references.env",
-                "impurity_references.env",
-                "impurity_references.env",
-                "impurity_references.env",
+                *("impurity_references.env" for _ in range(6)),
             ],
         )
         self.assertEqual(
@@ -200,6 +199,35 @@ class GoldenUpdateTests(unittest.TestCase):
             self.assertEqual(self._run(), 1)
 
         self.assertIn("campaign inputs changed", errors.getvalue())
+
+    def test_candidate_bootstrap_must_be_declared(self) -> None:
+        self.harness.set_bundle_class("candidate")
+        declaration = golden_update._load_declaration(
+            golden_update.REGRESSION_ROOT / "golden_campaigns.json",
+            "legacy_case",
+        )
+        declaration["source_bundle_class"] = "candidate"
+
+        with patch.object(
+            golden_update,
+            "_load_declaration",
+            return_value=declaration,
+        ):
+            self.assertEqual(self._run(), 0)
+
+        self.assertEqual(self.run_suite.call_args.args[7], "candidate")
+        self.assertEqual(
+            self._state()["inputs"]["source_bundle_class"],
+            "candidate",
+        )
+
+    def test_candidate_bootstrap_is_rejected_by_default(self) -> None:
+        self.harness.set_bundle_class("candidate")
+
+        with redirect_stderr(StringIO()) as errors:
+            self.assertEqual(self._run(), 1)
+
+        self.assertIn("requires bundle_class=golden", errors.getvalue())
 
     def _arguments(self, *extra: str) -> list[str]:
         return [

--- a/regression_tests/tests/test_golden_update.py
+++ b/regression_tests/tests/test_golden_update.py
@@ -63,7 +63,7 @@ class GoldenUpdateTests(unittest.TestCase):
         )
         self.validate_published = self._patch("_validate_published")
 
-    def test_update_stops_at_gate_then_continues_in_order(self) -> None:
+    def test_update_runs_through_then_publishes_after_campaign_acceptance(self) -> None:
         suites = []
 
         def run_suite(*args, **kwargs):
@@ -73,27 +73,8 @@ class GoldenUpdateTests(unittest.TestCase):
 
         self.run_suite.side_effect = run_suite
         self.assertEqual(self._run(), 0)
-        self.assertEqual(suites, [("cold_matrix", False, False)])
         state = self._state()
         self.assertEqual(state["status"], "awaiting_acceptance")
-        self.assertEqual(state["stages"][0]["status"], "awaiting_acceptance")
-        self.assertEqual(self._run("--accept", "cold_matrix"), 0)
-        self.assertEqual(suites[-1][0], "warm")
-        self.assertEqual(
-            self._state()["stages"][1]["status"],
-            "awaiting_acceptance",
-        )
-        self.assertEqual(self._run("--accept", "warm_reference"), 0)
-        self.assertEqual(
-            [suite for suite, _, _ in suites[-2:]],
-            ["impurity_references", "impurity_references"],
-        )
-        self.assertEqual(
-            self._state()["stages"][3]["status"],
-            "awaiting_acceptance",
-        )
-        self.assertEqual(self._run("--accept", "impurity_references"), 0)
-
         self.assertEqual(
             [suite for suite, _, _ in suites],
             [
@@ -109,6 +90,13 @@ class GoldenUpdateTests(unittest.TestCase):
                 "impurity_mixture",
             ],
         )
+        self.assertEqual(state["acceptance"]["status"], "pending")
+        self.assertEqual(
+            state["acceptance"]["required_stages"],
+            ["cold_matrix", "warm_reference", "impurity_references"],
+        )
+        self.assertFalse(self.output.exists())
+        self.assertEqual(self._run("--accept", "campaign"), 0)
         self.assertEqual(self.promote_bundle.call_count, 1)
         self.assertEqual(self.promote_mapped_bundle.call_count, 3)
         calls = self.run_suite.call_args_list
@@ -135,6 +123,7 @@ class GoldenUpdateTests(unittest.TestCase):
             state["verification_candidate"]["root"],
             state["active_bundle"],
         )
+        self.assertEqual(state["acceptance"]["status"], "accepted")
         self.assertIsNotNone(state["stages"][0].get("accepted_utc"))
         self.assertTrue(self.output.exists())
         self.assertEqual(self.publish_campaign_bundle.call_count, 1)
@@ -156,11 +145,12 @@ class GoldenUpdateTests(unittest.TestCase):
         self.assertEqual(self._run("--only", "warm"), 0)
         state = self._state()
         self.assertEqual(state["stages"][0]["status"], "skipped")
-        self.assertEqual(state["stages"][1]["status"], "awaiting_acceptance")
+        self.assertEqual(state["stages"][1]["status"], "completed")
+        self.assertEqual(state["status"], "awaiting_acceptance")
         self.assertEqual(len(state["warnings"]), 1)
 
         self.assertEqual(
-            self._run("--only", "warm", "--accept", "warm_reference"),
+            self._run("--only", "warm", "--accept", "campaign"),
             0,
         )
         self.assertEqual(
@@ -188,8 +178,10 @@ class GoldenUpdateTests(unittest.TestCase):
             self.assertEqual(self._run(), 1)
             self.assertEqual(self._run(), 0)
 
-        self.assertEqual(calls, [False, True])
-        self.assertEqual(self._state()["stages"][0]["status"], "awaiting_acceptance")
+        self.assertEqual(calls[:2], [False, True])
+        self.assertEqual(len(calls), 11)
+        self.assertEqual(self._state()["stages"][0]["status"], "completed")
+        self.assertEqual(self._state()["status"], "awaiting_acceptance")
 
     def test_changed_source_settings_reject_resume(self) -> None:
         self.assertEqual(self._run(), 0)
@@ -200,20 +192,9 @@ class GoldenUpdateTests(unittest.TestCase):
 
         self.assertIn("campaign inputs changed", errors.getvalue())
 
-    def test_candidate_bootstrap_must_be_declared(self) -> None:
+    def test_candidate_bootstrap_must_be_explicit(self) -> None:
         self.harness.set_bundle_class("candidate")
-        declaration = golden_update._load_declaration(
-            golden_update.REGRESSION_ROOT / "golden_campaigns.json",
-            "legacy_case",
-        )
-        declaration["source_bundle_class"] = "candidate"
-
-        with patch.object(
-            golden_update,
-            "_load_declaration",
-            return_value=declaration,
-        ):
-            self.assertEqual(self._run(), 0)
+        self.assertEqual(self._run("--bootstrap-candidate"), 0)
 
         self.assertEqual(self.run_suite.call_args.args[7], "candidate")
         self.assertEqual(

--- a/regression_tests/tests/test_golden_update.py
+++ b/regression_tests/tests/test_golden_update.py
@@ -335,6 +335,46 @@ class GoldenUpdateTests(unittest.TestCase):
 
         self.assertIn("campaign inputs changed", errors.getvalue())
 
+    def test_unrelated_shared_catalog_change_allows_acceptance(self) -> None:
+        self.assertEqual(self._run(), 0)
+        run_count = self.run_suite.call_count
+        document = json.loads(self.campaigns.read_text(encoding="utf-8"))
+        diverted = document["campaigns"]["diverted_case"]
+        diverted["stages"][0]["acceptance_required"] = False
+        self.campaigns.write_text(
+            json.dumps(document, indent=2) + "\n", encoding="utf-8"
+        )
+
+        self.assertEqual(self._run("--accept", "campaign"), 0)
+
+        state = self._state()
+        refresh = state["campaign_catalog_refreshes"][0]
+        self.assertEqual(state["status"], "published")
+        self.assertEqual(self.run_suite.call_count, run_count)
+        self.assertEqual(refresh["case_id"], "legacy_case")
+        self.assertNotEqual(
+            refresh["previous_campaign_catalog"]["sha256"],
+            refresh["campaign_catalog"]["sha256"],
+        )
+        self.assertEqual(
+            state["inputs"]["campaign_catalog"],
+            refresh["campaign_catalog"],
+        )
+
+    def test_selected_case_catalog_change_still_rejects_acceptance(self) -> None:
+        self.assertEqual(self._run(), 0)
+        document = json.loads(self.campaigns.read_text(encoding="utf-8"))
+        legacy = document["campaigns"]["legacy_case"]
+        legacy["stages"][0]["acceptance_required"] = False
+        self.campaigns.write_text(
+            json.dumps(document, indent=2) + "\n", encoding="utf-8"
+        )
+
+        with redirect_stderr(StringIO()) as errors:
+            self.assertEqual(self._run("--accept", "campaign"), 1)
+
+        self.assertIn("campaign inputs changed", errors.getvalue())
+
     def test_candidate_bootstrap_must_be_explicit(self) -> None:
         self.harness.set_bundle_class("candidate")
         self.assertEqual(self._run("--bootstrap-candidate"), 0)

--- a/regression_tests/tests/test_golden_update.py
+++ b/regression_tests/tests/test_golden_update.py
@@ -183,6 +183,62 @@ class GoldenUpdateTests(unittest.TestCase):
         self.assertEqual(self._state()["stages"][0]["status"], "completed")
         self.assertEqual(self._state()["status"], "awaiting_acceptance")
 
+    def test_failed_stage_retry_preserves_evidence_and_completed_stages(self) -> None:
+        attempted_run_ids = []
+        failed_once = False
+
+        def run_suite(*args, **kwargs):
+            nonlocal failed_once
+            run_id = args[6]
+            attempted_run_ids.append(run_id)
+            if args[1] == "stored_field_compatibility" and not failed_once:
+                failed_once = True
+                return self._suite_summary(run_id, "failed")
+            return self._passing_suite(*args, **kwargs)
+
+        self.run_suite.side_effect = run_suite
+        with redirect_stderr(StringIO()):
+            self.assertEqual(self._run(), 1)
+
+        failed_state = self._state()
+        failed_stage = failed_state["stages"][5]
+        failed_summary = failed_stage["summary"]
+        self.assertEqual(failed_state["status"], "failed")
+        self.assertEqual(failed_stage["status"], "failed")
+        self.assertEqual(len(attempted_run_ids), 6)
+
+        self.assertEqual(self._run("--retry-failed"), 0)
+        state = self._state()
+        retried_stage = state["stages"][5]
+        self.assertEqual(state["status"], "awaiting_acceptance")
+        self.assertEqual(retried_stage["status"], "completed")
+        self.assertEqual(retried_stage["retry_count"], 1)
+        self.assertEqual(len(retried_stage["failed_attempts"]), 1)
+        self.assertEqual(
+            retried_stage["failed_attempts"][0]["summary"], failed_summary
+        )
+        self.assertEqual(
+            attempted_run_ids[6],
+            "golden-test-stored_field_compatibility-retry-1",
+        )
+        self.assertEqual(
+            attempted_run_ids.count("golden-test-cold_matrix"), 1
+        )
+        self.assertFalse(self.run_suite.call_args_list[6].kwargs["resume"])
+
+        self.assertEqual(self._run("--accept", "campaign"), 0)
+        published_files = dict(self.publish_campaign_bundle.call_args.args[4])
+        self.assertIn(
+            "stages/stored_field_compatibility/failed_attempts/001/"
+            "suite_summary.json",
+            published_files,
+        )
+
+    def test_retry_requires_one_failed_stage(self) -> None:
+        with redirect_stderr(StringIO()) as errors:
+            self.assertEqual(self._run("--retry-failed"), 1)
+        self.assertIn("no single failed stage", errors.getvalue())
+
     def test_changed_source_settings_reject_resume(self) -> None:
         self.assertEqual(self._run(), 0)
         with self.harness.settings.open("a", encoding="utf-8") as stream:
@@ -232,9 +288,12 @@ class GoldenUpdateTests(unittest.TestCase):
             return golden_update.main(self._arguments(*extra))
 
     def _passing_suite(self, *args, **kwargs):
-        path = self.root / f"{args[1]}-summary.json"
+        return self._suite_summary(args[6], "passed")
+
+    def _suite_summary(self, run_id: str, status: str):
+        path = self.root / f"{run_id}-summary.json"
         summary = {
-            "status": "passed",
+            "status": status,
             "execution_inputs": {
                 "build_manifest": golden_update._file_record(
                     self.build.metadata_path,

--- a/regression_tests/tests/test_golden_update.py
+++ b/regression_tests/tests/test_golden_update.py
@@ -28,6 +28,21 @@ class GoldenUpdateTests(unittest.TestCase):
         harness_root.mkdir()
         self.harness = create_harness(harness_root)
         self.harness.set_bundle_class("golden")
+        self.campaigns = self.root / "golden_campaigns.json"
+        self.campaigns.write_text(
+            (REGRESSION_ROOT / "golden_campaigns.json").read_text(
+                encoding="utf-8"
+            ),
+            encoding="utf-8",
+        )
+        schemas = self.root / "schemas"
+        schemas.mkdir()
+        (schemas / "golden-campaigns.schema.json").write_text(
+            (
+                REGRESSION_ROOT / "schemas/golden-campaigns.schema.json"
+            ).read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
         self.workspace = self.root / "campaign"
         self.output = self.root / "new-golden"
         self.build = SimpleNamespace(
@@ -116,6 +131,15 @@ class GoldenUpdateTests(unittest.TestCase):
         self.assertEqual(
             self.promote_bundle.call_args.kwargs["matrix_warm_roles"],
             ("warm_restart",),
+        )
+        impurity_mappings = self.promote_mapped_bundle.call_args_list[2].args[2]
+        self.assertEqual(
+            [mapping["roles"] for mapping in impurity_mappings],
+            [
+                ["warm_impurity_off_reference"],
+                ["warm_impurity_n_reference"],
+                ["warm_impurity_nw_reference"],
+            ],
         )
         state = self._state()
         self.assertEqual(state["status"], "published")
@@ -239,6 +263,69 @@ class GoldenUpdateTests(unittest.TestCase):
             self.assertEqual(self._run("--retry-failed"), 1)
         self.assertIn("no single failed stage", errors.getvalue())
 
+    def test_retry_from_rewinds_to_preceding_candidate(self) -> None:
+        failed_once = False
+
+        def run_suite(*args, **kwargs):
+            nonlocal failed_once
+            if args[1] == "impurity_mixture" and not failed_once:
+                failed_once = True
+                return self._suite_summary(args[6], "failed")
+            return self._passing_suite(*args, **kwargs)
+
+        self.run_suite.side_effect = run_suite
+        with redirect_stderr(StringIO()):
+            self.assertEqual(self._run(), 1)
+
+        document = json.loads(self.campaigns.read_text(encoding="utf-8"))
+        stages = document["campaigns"]["legacy_case"]["stages"]
+        corrected = next(
+            stage for stage in stages if stage["id"] == "impurity_references"
+        )
+        corrected["role_mappings"][0]["roles"].append(
+            "warm_impurity_off_restart"
+        )
+        self.campaigns.write_text(
+            json.dumps(document, indent=2) + "\n", encoding="utf-8"
+        )
+
+        calls_before_retry = self.run_suite.call_count
+        self.assertEqual(self._run("--retry-from", "impurity_references"), 0)
+        self.assertEqual(self.run_suite.call_count - calls_before_retry, 7)
+
+        state = self._state()
+        impurity_restarts = state["stages"][2]
+        impurity_references = state["stages"][3]
+        verification = state["stages"][-1]
+        self.assertEqual(impurity_restarts.get("retry_count", 0), 0)
+        self.assertEqual(impurity_references["retry_count"], 1)
+        self.assertEqual(verification["retry_count"], 1)
+        self.assertEqual(len(impurity_references["archived_attempts"]), 1)
+        self.assertEqual(
+            impurity_references["archived_attempts"][0]["declaration"]
+            ["role_mappings"][0]["roles"],
+            ["warm_impurity_off_reference"],
+        )
+        self.assertTrue(
+            impurity_references["candidate"].endswith(
+                "candidates/impurity_references-retry-1"
+            )
+        )
+        self.assertEqual(
+            self.run_suite.call_args_list[calls_before_retry].args[6],
+            "golden-test-impurity_references-retry-1",
+        )
+        self.assertEqual(len(state["campaign_amendments"]), 1)
+        self.assertEqual(state["status"], "awaiting_acceptance")
+
+        self.assertEqual(self._run("--accept", "campaign"), 0)
+        published_files = dict(self.publish_campaign_bundle.call_args.args[4])
+        self.assertIn(
+            "stages/impurity_references/archived_attempts/001/"
+            "suite_summary.json",
+            published_files,
+        )
+
     def test_changed_source_settings_reject_resume(self) -> None:
         self.assertEqual(self._run(), 0)
         with self.harness.settings.open("a", encoding="utf-8") as stream:
@@ -280,6 +367,8 @@ class GoldenUpdateTests(unittest.TestCase):
             str(self.output),
             "--bundle-version",
             "golden-test-1",
+            "--campaigns",
+            str(self.campaigns),
             *extra,
         ]
 

--- a/regression_tests/tests/test_preparation.py
+++ b/regression_tests/tests/test_preparation.py
@@ -125,6 +125,7 @@ class RunPreparationTests(unittest.TestCase):
         self.assertEqual(
             plan["parameter_overrides"],
             {
+                "compute_from_flux": True,
                 "impurity_radiation": True,
             },
         )

--- a/regression_tests/tests/test_preparation.py
+++ b/regression_tests/tests/test_preparation.py
@@ -342,6 +342,10 @@ class RunPreparationTests(unittest.TestCase):
                 coarse_mesh.resolve(),
             )
             self.assertEqual(len(stage.command), 2)
+            self.assertEqual(
+                (stage.path / "inputs/impurity_model.nml").resolve(),
+                (self.bundle / "inputs/impurity_model_w.nml").resolve(),
+            )
             parameters = (stage.path / "param.txt").read_text(encoding="utf-8")
             for assignment in (
                 "steady = .false.",

--- a/regression_tests/tests/test_reference_publication.py
+++ b/regression_tests/tests/test_reference_publication.py
@@ -20,6 +20,7 @@ from bundle.promotion import (  # noqa: E402
 from bundle.validation import validate_bundle_root  # noqa: E402
 from support.errors import BundleError  # noqa: E402
 from support.files import file_identity  # noqa: E402
+from references.mapped import collect_mapped_references  # noqa: E402
 from tests.fixtures.case_data import write_case_source  # noqa: E402
 from tests.fixtures.harness import run_command  # noqa: E402
 
@@ -211,6 +212,34 @@ class ReferencePublicationTests(unittest.TestCase):
                 (self.output / artifact["path"]).read_text(encoding="utf-8"),
                 expected,
             )
+
+    def test_mapped_reference_accepts_a_declared_output_role(self) -> None:
+        summary_path = self._write_mapped_summary("cold_step_fixed")
+        summary = _load_json(summary_path)
+        manifest = _load_json(self.candidate / "manifest.json")
+        case = load_case_definition("legacy_case", REGRESSION_ROOT / "cases")
+        workflow = case["workflows"]["cold_step_fixed"]
+        workflow["default_layout"] = "mpi4_omp4"
+        workflow["output_roles"] = ["warm_reference"]
+
+        references = collect_mapped_references(
+            summary,
+            [
+                {
+                    "workflow": "cold_step_fixed",
+                    "roles": ["warm_reference"],
+                }
+            ],
+            case,
+            self.candidate,
+            manifest,
+        )
+
+        self.assertEqual(references.items[0].role, "warm_reference")
+        self.assertEqual(
+            references.items[0].solution.read_text(encoding="utf-8"),
+            "cold_step_fixed\n",
+        )
 
     def test_failed_suite_is_not_publishable(self) -> None:
         summary = _load_json(self.summary)

--- a/regression_tests/tools/bundle/case_definition.py
+++ b/regression_tests/tools/bundle/case_definition.py
@@ -134,6 +134,7 @@ def _normalize_workflow(declaration: dict[str, Any]) -> dict[str, Any]:
     _copy_if_present(declaration, workflow, "mesh", "mesh_role")
     _copy_if_present(declaration, workflow, "restart", "restart_role")
     _copy_if_present(declaration, workflow, "reference", "reference_role")
+    _copy_if_present(declaration, workflow, "outputs", "output_roles")
     _copy_if_present(
         declaration,
         workflow,

--- a/regression_tests/tools/bundle/cases.py
+++ b/regression_tests/tools/bundle/cases.py
@@ -68,8 +68,11 @@ def workflow_required_roles(workflow: dict[str, Any]) -> set[str]:
 def _validate_case_workflows(case: dict[str, Any]) -> None:
     declared_roles = set(case.get("bundle_files", {}))
     for workflow_id, workflow in case["workflows"].items():
+        used_roles = workflow_required_roles(workflow) | set(
+            workflow.get("output_roles", [])
+        )
         unknown = (
-            sorted(workflow_required_roles(workflow) - declared_roles)
+            sorted(used_roles - declared_roles)
             if declared_roles
             else []
         )

--- a/regression_tests/tools/comparison/fixed/hdf5.py
+++ b/regression_tests/tools/comparison/fixed/hdf5.py
@@ -8,6 +8,7 @@ from typing import Any
 import h5py
 
 from comparison.fixed.data import storage_format
+from comparison.fixed.magnetic import compare_magnetic
 from comparison.fixed.mesh import compare_mesh
 from comparison.fixed.solution import compare_solution
 from comparison.fixed.transport import compare_transport
@@ -50,6 +51,12 @@ def compare_hdf5_files(
                     failures,
                 )
             report["transport_1d"] = compare_transport(
+                reference,
+                candidate,
+                tolerances,
+                failures,
+            )
+            report["magnetic"] = compare_magnetic(
                 reference,
                 candidate,
                 tolerances,

--- a/regression_tests/tools/comparison/fixed/magnetic.py
+++ b/regression_tests/tools/comparison/fixed/magnetic.py
@@ -1,0 +1,69 @@
+"""Optional magnetic-geometry contract comparison."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import h5py
+import numpy as np
+
+from comparison.fixed.data import numeric_comparison, optional_group
+
+
+def compare_magnetic(
+    reference: h5py.File,
+    candidate: h5py.File,
+    tolerances: dict[str, Any],
+    failures: list[str],
+) -> dict[str, Any]:
+    """Compare every direct dataset in the reference magnetic group."""
+    reference_group = optional_group(reference, "magnetic")
+    candidate_group = optional_group(candidate, "magnetic")
+    if reference_group is None:
+        return {"present": False, "passed": True, "datasets": {}}
+    if candidate_group is None:
+        failures.append("candidate is missing magnetic data")
+        return {"present": True, "passed": False, "datasets": {}}
+
+    datasets: dict[str, dict[str, Any]] = {}
+    for name, reference_dataset in reference_group.items():
+        if not isinstance(reference_dataset, h5py.Dataset):
+            continue
+        candidate_dataset = candidate_group.get(name)
+        if not isinstance(candidate_dataset, h5py.Dataset):
+            datasets[name] = {"passed": False, "reason": "dataset missing"}
+            failures.append(f"magnetic/{name} is missing")
+            continue
+
+        reference_array = np.asarray(reference_dataset)
+        candidate_array = np.asarray(candidate_dataset)
+        if reference_array.dtype.kind in "biuOSU":
+            metrics = _exact_comparison(reference_array, candidate_array)
+        else:
+            metrics = numeric_comparison(
+                reference_array,
+                candidate_array,
+                tolerances,
+            )
+        datasets[name] = metrics
+        if not metrics["passed"]:
+            failures.append(f"magnetic/{name} differs")
+
+    return {
+        "present": True,
+        "passed": all(result["passed"] for result in datasets.values()),
+        "datasets": datasets,
+    }
+
+
+def _exact_comparison(
+    reference: np.ndarray,
+    candidate: np.ndarray,
+) -> dict[str, Any]:
+    """Compare categorical and integer magnetic metadata exactly."""
+    return {
+        "passed": np.array_equal(reference, candidate),
+        "mode": "exact",
+        "reference_shape": list(reference.shape),
+        "candidate_shape": list(candidate.shape),
+    }

--- a/regression_tests/tools/comparison/shared/reporting.py
+++ b/regression_tests/tools/comparison/shared/reporting.py
@@ -59,6 +59,18 @@ def print_fixed_summary(report: dict[str, Any]) -> None:
             f"{format_metric(maximum_metric(transport_metrics, 'normalized_linf'))}"
         )
 
+    magnetic = report["hdf5"].get("magnetic", {})
+    magnetic_metrics = list(magnetic.get("datasets", {}).values())
+    if magnetic.get("present", False):
+        print(
+            "magnetic: "
+            f"{_pass_label(magnetic.get('passed', False))} "
+            "max relL2="
+            f"{format_metric(maximum_metric(magnetic_metrics, 'relative_l2'))} "
+            "max nLinf="
+            f"{format_metric(maximum_metric(magnetic_metrics, 'normalized_linf'))}"
+        )
+
     failures = report["failures"]
     for failure in failures[:10]:
         print(f"FAIL: {failure}")

--- a/regression_tests/tools/golden_update.py
+++ b/regression_tests/tools/golden_update.py
@@ -62,7 +62,8 @@ def update_campaign(args: argparse.Namespace) -> dict[str, Any]:
     settings = read_settings(source_settings)
     source_bundle = bundle_root_from_settings(settings)
     validate_bundle_root(source_bundle, args.cases)
-    require_bundle_class(source_bundle, args.cases, "golden")
+    source_bundle_class = declaration.get("source_bundle_class", "golden")
+    require_bundle_class(source_bundle, args.cases, source_bundle_class)
     source_manifest = load_json(source_bundle / "manifest.json", "bundle manifest")
     if source_manifest["case_id"] != args.case_id:
         raise BundleError("campaign and source bundle use different cases")
@@ -75,6 +76,7 @@ def update_campaign(args: argparse.Namespace) -> dict[str, Any]:
         "run_id": args.run_id,
         "source_settings": _file_record(source_settings),
         "source_bundle": str(source_bundle),
+        "source_bundle_class": source_bundle_class,
         "source_manifest": _file_record(source_bundle / "manifest.json"),
         "campaign_catalog": _file_record(args.campaigns),
         "output": str(args.output.expanduser().resolve()),
@@ -122,7 +124,7 @@ def _load_or_create(
         "inputs": inputs,
         "build": {"status": "pending"},
         "active_bundle": inputs["source_bundle"],
-        "active_bundle_class": "golden",
+        "active_bundle_class": inputs["source_bundle_class"],
         "active_settings": None,
         "warnings": _selection_warnings(declaration, selected, partial),
         "publication": {"status": "pending"},

--- a/regression_tests/tools/golden_update.py
+++ b/regression_tests/tools/golden_update.py
@@ -33,6 +33,11 @@ from support.time import utc_now
 REGRESSION_ROOT = Path(__file__).resolve().parents[1]
 REPOSITORY_ROOT = REGRESSION_ROOT.parent
 STATE_FILE = "campaign.json"
+ATTEMPT_RECORD_FIELDS = (
+    "summary",
+    "layout_pair_report",
+    "old_golden_report",
+)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -93,9 +98,35 @@ def update_campaign(args: argparse.Namespace) -> dict[str, Any]:
         selected,
         partial,
     )
+    if args.retry_failed:
+        _retry_failed_stage(state)
     if args.accept:
         _accept_campaign(state, args.accept)
     return _advance(state, args)
+
+
+def _retry_failed_stage(state: dict[str, Any]) -> None:
+    """Archive one failed stage attempt and make the stage runnable again."""
+    failed = [stage for stage in state["stages"] if stage["status"] == "failed"]
+    if state["status"] != "failed" or len(failed) != 1:
+        raise BundleError("golden campaign has no single failed stage to retry")
+
+    stage = failed[0]
+    retry_count = stage.get("retry_count", 0) + 1
+    attempt = {
+        "attempt": retry_count - 1,
+        "archived_utc": utc_now(),
+    }
+    for name in ATTEMPT_RECORD_FIELDS:
+        if name in stage:
+            attempt[name] = stage.pop(name)
+    if "failed_utc" in stage:
+        attempt["failed_utc"] = stage.pop("failed_utc")
+    stage.setdefault("failed_attempts", []).append(attempt)
+    stage["retry_count"] = retry_count
+    stage["status"] = "pending"
+    state["status"] = "ready"
+    _save(state)
 
 
 def _load_or_create(
@@ -214,7 +245,7 @@ def _run_stage(
         args.layouts,
         args.suites,
         args.tolerances,
-        f"{state['inputs']['run_id']}-{stage['id']}",
+        _stage_run_id(state, stage),
         state["active_bundle_class"],
         compare=stage["kind"] not in {"matrix", "reference"},
         resume=resume,
@@ -236,6 +267,7 @@ def _run_stage(
         stage["old_golden_report"] = _file_record(old_golden_path)
     if not passed:
         stage["status"] = "failed"
+        stage["failed_utc"] = utc_now()
         state["status"] = "failed"
         _save(state)
         raise BundleError(f"golden stage failed: {stage['id']}")
@@ -248,6 +280,14 @@ def _run_stage(
         _activate_candidate(state, stage)
     state["status"] = stage["status"]
     _save(state)
+
+
+def _stage_run_id(state: dict[str, Any], stage: dict[str, Any]) -> str:
+    run_id = f"{state['inputs']['run_id']}-{stage['id']}"
+    retry_count = stage.get("retry_count", 0)
+    if retry_count:
+        run_id += f"-retry-{retry_count}"
+    return run_id
 
 
 def _record_matrix_reports(
@@ -468,40 +508,59 @@ def _campaign_provenance_files(state: dict[str, Any]) -> list[tuple[str, Path]]:
         ("build/build_metadata.json", build_metadata),
     ]
     for stage in state["stages"]:
-        summary_record = stage.get("summary")
-        if summary_record is None:
-            continue
-        summary_path = _recorded_path(summary_record, "suite summary")
         prefix = f"stages/{stage['id']}"
-        documents = [("suite_summary.json", summary_path)]
-        documents.extend(
-            (f"{name}.json", _recorded_path(stage[name], name))
-            for name in ("layout_pair_report", "old_golden_report")
-            if name in stage
-        )
-        report_paths = set()
-        for name, path in documents:
-            files.append((f"{prefix}/{name}", path))
-            report_paths.update(_comparison_report_paths(load_json(path, name)))
-
-        summary = load_json(summary_path, "suite summary")
-        if summary.get("execution_inputs", {}).get("build_manifest") != build_record:
-            raise BundleError(f"golden stage used another build: {stage['id']}")
-        for number, result in enumerate(summary.get("results", []), start=1):
-            run = Path(result["run_directory"])
-            run_prefix = f"{prefix}/runs/{number:03d}"
-            for name in ("run_plan.json", "run_metadata.json"):
-                files.append((f"{run_prefix}/{name}", run / name))
-                for nested in sorted(run.glob(f"stages/*/{name}")):
-                    files.append(
-                        (
-                            f"{run_prefix}/stages/{nested.parent.name}/{name}",
-                            nested,
-                        )
-                    )
-        for number, path in enumerate(sorted(report_paths), start=1):
-            files.append((f"{prefix}/comparisons/{number:03d}.json", path))
+        if stage.get("summary") is not None:
+            _append_attempt_provenance(
+                files, prefix, stage, build_record, stage["id"]
+            )
+        for attempt in stage.get("failed_attempts", []):
+            attempt_number = attempt["attempt"] + 1
+            _append_attempt_provenance(
+                files,
+                f"{prefix}/failed_attempts/{attempt_number:03d}",
+                attempt,
+                build_record,
+                f"{stage['id']} failed attempt {attempt_number}",
+            )
     return files
+
+
+def _append_attempt_provenance(
+    files: list[tuple[str, Path]],
+    prefix: str,
+    attempt: dict[str, Any],
+    build_record: dict[str, Any],
+    label: str,
+) -> None:
+    summary_path = _recorded_path(attempt["summary"], "suite summary")
+    documents = [("suite_summary.json", summary_path)]
+    documents.extend(
+        (f"{name}.json", _recorded_path(attempt[name], name))
+        for name in ("layout_pair_report", "old_golden_report")
+        if name in attempt
+    )
+    report_paths = set()
+    for name, path in documents:
+        files.append((f"{prefix}/{name}", path))
+        report_paths.update(_comparison_report_paths(load_json(path, name)))
+
+    summary = load_json(summary_path, "suite summary")
+    if summary.get("execution_inputs", {}).get("build_manifest") != build_record:
+        raise BundleError(f"golden stage used another build: {label}")
+    for number, result in enumerate(summary.get("results", []), start=1):
+        run = Path(result["run_directory"])
+        run_prefix = f"{prefix}/runs/{number:03d}"
+        for name in ("run_plan.json", "run_metadata.json"):
+            files.append((f"{run_prefix}/{name}", run / name))
+            for nested in sorted(run.glob(f"stages/*/{name}")):
+                files.append(
+                    (
+                        f"{run_prefix}/stages/{nested.parent.name}/{name}",
+                        nested,
+                    )
+                )
+    for number, path in enumerate(sorted(report_paths), start=1):
+        files.append((f"{prefix}/comparisons/{number:03d}.json", path))
 
 
 def _comparison_report_paths(document: Any) -> set[Path]:
@@ -642,6 +701,11 @@ def _argument_parser() -> argparse.ArgumentParser:
     update.add_argument("--bundle-version", required=True, metavar="VERSION")
     update.add_argument("--workspace", type=Path)
     update.add_argument("--accept", choices=("campaign",))
+    update.add_argument(
+        "--retry-failed",
+        action="store_true",
+        help="archive and rerun the campaign's failed stage",
+    )
     update.add_argument(
         "--bootstrap-candidate",
         action="store_true",

--- a/regression_tests/tools/golden_update.py
+++ b/regression_tests/tools/golden_update.py
@@ -38,6 +38,20 @@ ATTEMPT_RECORD_FIELDS = (
     "layout_pair_report",
     "old_golden_report",
 )
+STAGE_RESULT_FIELDS = ATTEMPT_RECORD_FIELDS + (
+    "candidate",
+    "candidate_settings",
+    "accepted_utc",
+    "failed_utc",
+)
+DECLARATION_STAGE_FIELDS = (
+    "id",
+    "kind",
+    "suite",
+    "component",
+    "acceptance_required",
+    "role_mappings",
+)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -97,7 +111,15 @@ def update_campaign(args: argparse.Namespace) -> dict[str, Any]:
         args.output,
         selected,
         partial,
+        allow_catalog_update=args.retry_from is not None,
     )
+    if args.retry_from:
+        _retry_from_stage(
+            state,
+            declaration,
+            args.retry_from,
+            inputs["campaign_catalog"],
+        )
     if args.retry_failed:
         _retry_failed_stage(state)
     if args.accept:
@@ -129,6 +151,99 @@ def _retry_failed_stage(state: dict[str, Any]) -> None:
     _save(state)
 
 
+def _retry_from_stage(
+    state: dict[str, Any],
+    declaration: dict[str, Any],
+    stage_id: str,
+    campaign_catalog: dict[str, Any],
+) -> None:
+    """Rewind a failed campaign to a corrected declaration stage."""
+    if state["status"] != "failed":
+        raise BundleError("golden campaign is not failed")
+    stages = state["stages"]
+    declared = declaration["stages"]
+    if [stage["id"] for stage in stages] != [stage["id"] for stage in declared]:
+        raise BundleError("golden campaign stage order changed")
+    indices = [index for index, stage in enumerate(stages) if stage["id"] == stage_id]
+    if not indices:
+        raise BundleError(f"unknown golden retry stage: {stage_id}")
+    start = indices[0]
+    if not any(stage["status"] == "failed" for stage in stages[start:]):
+        raise BundleError("golden retry stage is after the recorded failure")
+
+    _restore_preceding_candidate(state, start)
+    for stage in stages[start:]:
+        if stage["status"] == "skipped":
+            continue
+        if any(name in stage for name in ATTEMPT_RECORD_FIELDS):
+            _archive_stage_attempt(stage)
+            stage["retry_count"] = stage.get("retry_count", 0) + 1
+        for name in STAGE_RESULT_FIELDS:
+            stage.pop(name, None)
+        stage["status"] = "pending"
+    for stage, current in zip(stages, declared):
+        _update_stage_declaration(stage, current)
+
+    previous_catalog = state["inputs"]["campaign_catalog"]
+    state.setdefault("campaign_amendments", []).append(
+        {
+            "amended_utc": utc_now(),
+            "retry_from": stage_id,
+            "previous_campaign_catalog": previous_catalog,
+            "campaign_catalog": campaign_catalog,
+        }
+    )
+    state["inputs"]["campaign_catalog"] = campaign_catalog
+    state["acceptance"] = {
+        "status": "pending",
+        "required_stages": [
+            stage["id"]
+            for stage in stages
+            if stage["status"] != "skipped" and stage["acceptance_required"]
+        ],
+    }
+    state["publication"] = {"status": "pending"}
+    state.pop("verification_candidate", None)
+    state["status"] = "ready"
+    _save(state)
+
+
+def _restore_preceding_candidate(state: dict[str, Any], start: int) -> None:
+    state["active_bundle"] = state["inputs"]["source_bundle"]
+    state["active_bundle_class"] = state["inputs"]["source_bundle_class"]
+    state["active_settings"] = state["build"].get("settings")
+    for stage in reversed(state["stages"][:start]):
+        if stage.get("candidate") and stage["status"] == "completed":
+            _activate_candidate(state, stage)
+            return
+
+
+def _update_stage_declaration(
+    stage: dict[str, Any], declaration: dict[str, Any]
+) -> None:
+    for name in DECLARATION_STAGE_FIELDS:
+        stage.pop(name, None)
+        if name in declaration:
+            stage[name] = declaration[name]
+
+
+def _archive_stage_attempt(stage: dict[str, Any]) -> None:
+    attempt = {
+        "attempt": stage.get("retry_count", 0),
+        "status": stage["status"],
+        "archived_utc": utc_now(),
+        "declaration": {
+            name: stage[name]
+            for name in DECLARATION_STAGE_FIELDS
+            if name in stage
+        },
+    }
+    for name in STAGE_RESULT_FIELDS:
+        if name in stage:
+            attempt[name] = stage[name]
+    stage.setdefault("archived_attempts", []).append(attempt)
+
+
 def _load_or_create(
     workspace: Path,
     inputs: dict[str, Any],
@@ -136,11 +251,15 @@ def _load_or_create(
     output: Path,
     selected: set[str],
     partial: bool,
+    allow_catalog_update: bool = False,
 ) -> dict[str, Any]:
     state_path = workspace / STATE_FILE
     if state_path.is_file():
         state = load_json(state_path, "golden campaign state")
-        if state.get("inputs") != inputs:
+        if state.get("inputs") != inputs and not (
+            allow_catalog_update
+            and _only_campaign_catalog_changed(state.get("inputs"), inputs)
+        ):
             raise BundleError("golden campaign inputs changed")
         return state
     if workspace.exists():
@@ -186,6 +305,19 @@ def _load_or_create(
     }
     _save(state)
     return state
+
+
+def _only_campaign_catalog_changed(
+    recorded: dict[str, Any] | None, current: dict[str, Any]
+) -> bool:
+    if recorded is None:
+        return False
+    old_catalog = recorded.get("campaign_catalog", {})
+    new_catalog = current.get("campaign_catalog", {})
+    if old_catalog.get("path") != new_catalog.get("path"):
+        return False
+    old_inputs = {**recorded, "campaign_catalog": new_catalog}
+    return old_inputs == current
 
 
 def _advance(state: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
@@ -283,11 +415,17 @@ def _run_stage(
 
 
 def _stage_run_id(state: dict[str, Any], stage: dict[str, Any]) -> str:
-    run_id = f"{state['inputs']['run_id']}-{stage['id']}"
+    run_id = f"{state['inputs']['run_id']}-{_stage_attempt_name(stage)}"
+
+    return run_id
+
+
+def _stage_attempt_name(stage: dict[str, Any]) -> str:
+    name = stage["id"]
     retry_count = stage.get("retry_count", 0)
     if retry_count:
-        run_id += f"-retry-{retry_count}"
-    return run_id
+        name += f"-retry-{retry_count}"
+    return name
 
 
 def _record_matrix_reports(
@@ -307,7 +445,11 @@ def _record_matrix_reports(
         ),
         "comparisons": comparisons,
     }
-    report_path = Path(state["workspace"]) / "reports" / f"{stage['id']}.json"
+    report_path = (
+        Path(state["workspace"])
+        / "reports"
+        / f"{_stage_attempt_name(stage)}.json"
+    )
     write_json_atomic(report_path, report, "matrix layout-pair report")
     stage["layout_pair_report"] = _file_record(report_path)
     if report["status"] != "passed":
@@ -372,7 +514,8 @@ def _compose_stage(
     settings_path: Path,
     args: argparse.Namespace,
 ) -> None:
-    candidate = Path(state["workspace"]) / "candidates" / stage["id"]
+    attempt_name = _stage_attempt_name(stage)
+    candidate = Path(state["workspace"]) / "candidates" / attempt_name
     stage["candidate"] = str(candidate)
     _save(state)
     if candidate.exists():
@@ -382,7 +525,7 @@ def _compose_stage(
             settings_path,
             summary_path,
             candidate,
-            f"{state['inputs']['bundle_version']}-{stage['id']}",
+            f"{state['inputs']['bundle_version']}-{attempt_name}",
             args.cases,
             bundle_class="candidate",
             matrix_warm_roles=("warm_restart",),
@@ -393,11 +536,11 @@ def _compose_stage(
             summary_path,
             stage["role_mappings"],
             candidate,
-            f"{state['inputs']['bundle_version']}-{stage['id']}",
+            f"{state['inputs']['bundle_version']}-{attempt_name}",
             args.cases,
         )
 
-    generated = Path(state["workspace"]) / "settings" / f"{stage['id']}.env"
+    generated = Path(state["workspace"]) / "settings" / f"{attempt_name}.env"
     _write_bundle_settings(settings_path, generated, candidate)
     stage["candidate_settings"] = _file_record(generated)
     _save(state)
@@ -521,6 +664,15 @@ def _campaign_provenance_files(state: dict[str, Any]) -> list[tuple[str, Path]]:
                 attempt,
                 build_record,
                 f"{stage['id']} failed attempt {attempt_number}",
+            )
+        for attempt in stage.get("archived_attempts", []):
+            attempt_number = attempt["attempt"] + 1
+            _append_attempt_provenance(
+                files,
+                f"{prefix}/archived_attempts/{attempt_number:03d}",
+                attempt,
+                build_record,
+                f"{stage['id']} archived attempt {attempt_number}",
             )
     return files
 
@@ -700,11 +852,17 @@ def _argument_parser() -> argparse.ArgumentParser:
     update.add_argument("--output", required=True, type=Path)
     update.add_argument("--bundle-version", required=True, metavar="VERSION")
     update.add_argument("--workspace", type=Path)
-    update.add_argument("--accept", choices=("campaign",))
-    update.add_argument(
+    recovery = update.add_mutually_exclusive_group()
+    recovery.add_argument("--accept", choices=("campaign",))
+    recovery.add_argument(
         "--retry-failed",
         action="store_true",
         help="archive and rerun the campaign's failed stage",
+    )
+    recovery.add_argument(
+        "--retry-from",
+        metavar="STAGE",
+        help="archive and rerun a failed campaign from a corrected stage",
     )
     update.add_argument(
         "--bootstrap-candidate",

--- a/regression_tests/tools/golden_update.py
+++ b/regression_tests/tools/golden_update.py
@@ -256,11 +256,19 @@ def _load_or_create(
     state_path = workspace / STATE_FILE
     if state_path.is_file():
         state = load_json(state_path, "golden campaign state")
-        if state.get("inputs") != inputs and not (
-            allow_catalog_update
-            and _only_campaign_catalog_changed(state.get("inputs"), inputs)
-        ):
-            raise BundleError("golden campaign inputs changed")
+        if state.get("inputs") != inputs:
+            catalog_only = _only_campaign_catalog_changed(
+                state.get("inputs"), inputs
+            )
+            if catalog_only and allow_catalog_update:
+                return state
+            if catalog_only and _declaration_matches_state(state, declaration):
+                _refresh_campaign_catalog(
+                    state,
+                    inputs["campaign_catalog"],
+                )
+            else:
+                raise BundleError("golden campaign inputs changed")
         return state
     if workspace.exists():
         raise BundleError(f"campaign workspace already exists: {workspace}")
@@ -318,6 +326,46 @@ def _only_campaign_catalog_changed(
         return False
     old_inputs = {**recorded, "campaign_catalog": new_catalog}
     return old_inputs == current
+
+
+def _declaration_matches_state(
+    state: dict[str, Any], declaration: dict[str, Any]
+) -> bool:
+    recorded_stages = [
+        {
+            name: stage[name]
+            for name in DECLARATION_STAGE_FIELDS
+            if name in stage
+        }
+        for stage in state.get("stages", [])
+    ]
+    current_stages = [
+        {
+            name: stage[name]
+            for name in DECLARATION_STAGE_FIELDS
+            if name in stage
+        }
+        for stage in declaration["stages"]
+    ]
+    return recorded_stages == current_stages
+
+
+def _refresh_campaign_catalog(
+    state: dict[str, Any], campaign_catalog: dict[str, Any]
+) -> None:
+    """Record an unrelated shared-catalog update without rewinding stages."""
+    previous_catalog = state["inputs"]["campaign_catalog"]
+    state.setdefault("campaign_catalog_refreshes", []).append(
+        {
+            "refreshed_utc": utc_now(),
+            "case_id": state["inputs"]["case_id"],
+            "reason": "selected case declaration unchanged",
+            "previous_campaign_catalog": previous_catalog,
+            "campaign_catalog": campaign_catalog,
+        }
+    )
+    state["inputs"]["campaign_catalog"] = campaign_catalog
+    _save(state)
 
 
 def _advance(state: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:

--- a/regression_tests/tools/golden_update.py
+++ b/regression_tests/tools/golden_update.py
@@ -51,7 +51,7 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def update_campaign(args: argparse.Namespace) -> dict[str, Any]:
-    """Create or continue one campaign until its next acceptance gate."""
+    """Create or continue one campaign until completion or final review."""
     if not IDENTIFIER_RE.fullmatch(args.run_id):
         raise BundleError(f"invalid golden run identifier: {args.run_id}")
     if not args.bundle_version.strip():
@@ -62,7 +62,7 @@ def update_campaign(args: argparse.Namespace) -> dict[str, Any]:
     settings = read_settings(source_settings)
     source_bundle = bundle_root_from_settings(settings)
     validate_bundle_root(source_bundle, args.cases)
-    source_bundle_class = declaration.get("source_bundle_class", "golden")
+    source_bundle_class = "candidate" if args.bootstrap_candidate else "golden"
     require_bundle_class(source_bundle, args.cases, source_bundle_class)
     source_manifest = load_json(source_bundle / "manifest.json", "bundle manifest")
     if source_manifest["case_id"] != args.case_id:
@@ -77,6 +77,7 @@ def update_campaign(args: argparse.Namespace) -> dict[str, Any]:
         "source_settings": _file_record(source_settings),
         "source_bundle": str(source_bundle),
         "source_bundle_class": source_bundle_class,
+        "bootstrap_candidate": args.bootstrap_candidate,
         "source_manifest": _file_record(source_bundle / "manifest.json"),
         "campaign_catalog": _file_record(args.campaigns),
         "output": str(args.output.expanduser().resolve()),
@@ -93,7 +94,7 @@ def update_campaign(args: argparse.Namespace) -> dict[str, Any]:
         partial,
     )
     if args.accept:
-        _accept(state, args.accept)
+        _accept_campaign(state, args.accept)
     return _advance(state, args)
 
 
@@ -117,6 +118,24 @@ def _load_or_create(
         raise BundleError(f"golden output already exists: {output}")
 
     workspace.mkdir(parents=True)
+    stages = [
+        {
+            **stage,
+            "status": (
+                "pending"
+                if not partial
+                or stage["kind"] == "verification"
+                or stage.get("component") in selected
+                else "skipped"
+            ),
+        }
+        for stage in declaration["stages"]
+    ]
+    review_stages = [
+        stage["id"]
+        for stage in stages
+        if stage["status"] != "skipped" and stage["acceptance_required"]
+    ]
     state = {
         "schema_version": 1,
         "workspace": str(workspace),
@@ -127,20 +146,12 @@ def _load_or_create(
         "active_bundle_class": inputs["source_bundle_class"],
         "active_settings": None,
         "warnings": _selection_warnings(declaration, selected, partial),
+        "acceptance": {
+            "status": "pending" if review_stages else "not_required",
+            "required_stages": review_stages,
+        },
         "publication": {"status": "pending"},
-        "stages": [
-            {
-                **stage,
-                "status": (
-                    "pending"
-                    if not partial
-                    or stage["kind"] == "verification"
-                    or stage.get("component") in selected
-                    else "skipped"
-                ),
-            }
-            for stage in declaration["stages"]
-        ],
+        "stages": stages,
     }
     _save(state)
     return state
@@ -151,18 +162,17 @@ def _advance(state: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
         _run_build(state, args)
 
     for stage in state["stages"]:
-        if stage["status"] == "awaiting_acceptance":
-            state["status"] = "awaiting_acceptance"
-            _save(state)
-            return state
         if stage["status"] in {"completed", "skipped"}:
             continue
         if stage["status"] == "failed":
             raise BundleError(f"golden stage failed: {stage['id']}")
         _run_stage(state, stage, args)
-        if stage["status"] == "awaiting_acceptance":
-            return state
 
+    _record_verification_candidate(state)
+    if state["acceptance"]["status"] == "pending":
+        state["status"] = "awaiting_acceptance"
+        _save(state)
+        return state
     return _publish(state, args)
 
 
@@ -233,12 +243,8 @@ def _run_stage(
     if stage["kind"] in {"matrix", "reference"}:
         _compose_stage(state, stage, summary_path, settings_path, args)
 
-    stage["status"] = (
-        "awaiting_acceptance"
-        if stage["acceptance_required"]
-        else "completed"
-    )
-    if stage["status"] == "completed" and stage.get("candidate"):
+    stage["status"] = "completed"
+    if stage.get("candidate"):
         _activate_candidate(state, stage)
     state["status"] = stage["status"]
     _save(state)
@@ -276,14 +282,23 @@ def _record_matrix_reports(
     return True
 
 
-def _accept(state: dict[str, Any], stage_id: str) -> None:
-    matching = [stage for stage in state["stages"] if stage["id"] == stage_id]
-    if len(matching) != 1 or matching[0]["status"] != "awaiting_acceptance":
-        raise BundleError(f"golden stage is not awaiting acceptance: {stage_id}")
-    matching[0]["status"] = "completed"
-    matching[0]["accepted_utc"] = utc_now()
-    if matching[0].get("candidate"):
-        _activate_candidate(state, matching[0])
+def _accept_campaign(state: dict[str, Any], acceptance: str) -> None:
+    if acceptance != "campaign":
+        raise BundleError("golden acceptance target must be 'campaign'")
+    if (
+        state["status"] != "awaiting_acceptance"
+        or state["acceptance"]["status"] != "pending"
+    ):
+        raise BundleError("golden campaign is not awaiting acceptance")
+    _record_verification_candidate(state)
+    accepted_utc = utc_now()
+    state["acceptance"].update(
+        {"status": "accepted", "accepted_utc": accepted_utc}
+    )
+    required = set(state["acceptance"]["required_stages"])
+    for stage in state["stages"]:
+        if stage["id"] in required:
+            stage["accepted_utc"] = accepted_utc
     state["status"] = "ready"
     _save(state)
 
@@ -607,6 +622,9 @@ def _print_status(state: dict[str, Any]) -> None:
     print(f"build: {state['build']['status']}")
     for stage in state["stages"]:
         print(f"{stage['id']}: {stage['status']}")
+    acceptance = state.get("acceptance")
+    if acceptance is not None:
+        print(f"campaign acceptance: {acceptance['status']}")
     for warning in state.get("warnings", []):
         print(f"warning: {warning}")
     if state.get("publication", {}).get("status") == "completed":
@@ -623,7 +641,12 @@ def _argument_parser() -> argparse.ArgumentParser:
     update.add_argument("--output", required=True, type=Path)
     update.add_argument("--bundle-version", required=True, metavar="VERSION")
     update.add_argument("--workspace", type=Path)
-    update.add_argument("--accept", metavar="STAGE")
+    update.add_argument("--accept", choices=("campaign",))
+    update.add_argument(
+        "--bootstrap-candidate",
+        action="store_true",
+        help="allow a candidate source for the first promotion of a new case",
+    )
     update.add_argument("--only", action="append", metavar="COMPONENT")
     update.add_argument("--build-jobs", type=parse_build_jobs, metavar="N")
     update.add_argument("--repository-root", type=Path, default=REPOSITORY_ROOT)

--- a/regression_tests/tools/references/mapped.py
+++ b/regression_tests/tools/references/mapped.py
@@ -52,7 +52,7 @@ def collect_mapped_references(
             role
             for name in ("restart_role", "reference_role")
             if (role := workflow.get(name))
-        }
+        } | set(workflow.get("output_roles", []))
         unknown = sorted(set(mapping["roles"]) - allowed_roles)
         if unknown:
             raise BundleError(

--- a/src/Definitions/types.f90
+++ b/src/Definitions/types.f90
@@ -454,8 +454,8 @@ MODULE types
      CHARACTER(len=1000) :: diffusion_1D_path ! where do we read 1D diffusion profiles from (only used if the import_diffusion_1D is on)
      LOGICAL             :: field_from_grid !if true, then reads equilibrium file n rectangular grid; if false - on nodes of the mesh
      LOGICAL             :: external_heating_from_grid !if true, then reads external heating file n rectangular grid; if false - on nodes of the mesh
-     LOGICAL             :: compute_from_flux ! if components B_R, B_Z are computed from flux or not
-     LOGICAL             :: divide_by_2pi     ! correspondng to flux definition if it is needed to divide by 2pi or not
+     LOGICAL             :: compute_from_flux = .TRUE. ! if components B_R, B_Z are computed from flux or not
+     LOGICAL             :: divide_by_2pi = .FALSE.    ! fallback convention when the field fit is unavailable
      INTEGER             :: field_dimensions(1:2) ! dimensions of magnetic field files (2D WEST cases so far)
      INTEGER             :: jtor_dimensions(1:2) ! dimensions of magnetic field files (2D WEST cases so far)
      INTEGER             :: puff_dimension ! number of timeslices in the puff file

--- a/src/Definitions/types.f90
+++ b/src/Definitions/types.f90
@@ -454,7 +454,7 @@ MODULE types
      CHARACTER(len=1000) :: diffusion_1D_path ! where do we read 1D diffusion profiles from (only used if the import_diffusion_1D is on)
      LOGICAL             :: field_from_grid !if true, then reads equilibrium file n rectangular grid; if false - on nodes of the mesh
      LOGICAL             :: external_heating_from_grid !if true, then reads external heating file n rectangular grid; if false - on nodes of the mesh
-     LOGICAL             :: compute_from_flux = .TRUE. ! if components B_R, B_Z are computed from flux or not
+     LOGICAL             :: compute_from_flux = .TRUE. ! derive B_R, B_Z and Jtor from bicubic psi when available
      LOGICAL             :: divide_by_2pi = .FALSE.    ! fallback convention when the field fit is unavailable
      INTEGER             :: field_dimensions(1:2) ! dimensions of magnetic field files (2D WEST cases so far)
      INTEGER             :: jtor_dimensions(1:2) ! dimensions of magnetic field files (2D WEST cases so far)

--- a/src/Definitions/types.f90
+++ b/src/Definitions/types.f90
@@ -469,6 +469,7 @@ MODULE types
      REAL*8 :: rho_core = 0.8d0
      REAL*8 :: rho_edge = 0.99d0
      REAL*8 :: rho_diffusion_model_max = 1.d0
+     CHARACTER(LEN=32) :: transport_region_policy = 'legacy_all_regions'
      REAL*8 :: c_bohm_i = 1.6d-4
      REAL*8 :: c_gyrobohm_i = 1.75d-2
      REAL*8 :: c_bohm_e = 8.d-5

--- a/src/Definitions/types.f90
+++ b/src/Definitions/types.f90
@@ -475,6 +475,7 @@ MODULE types
      REAL*8 :: c_bohm_e = 8.d-5
      REAL*8 :: c_gyrobohm_e = 3.5d-2
      REAL*8 :: c_bohm_n = 1.d0
+     REAL*8 :: c_bohm_n_rho_slope = 0.7d0
      REAL*8 :: prandtl = 1.d0
      INTEGER :: pinch_model = 1
      REAL*8 :: c_pinch = 0.5d0

--- a/src/HDG/hdg_BC.f90
+++ b/src/HDG/hdg_BC.f90
@@ -11,6 +11,7 @@ SUBROUTINE HDG_BC()
   USE LinearAlgebra
   USE physics
   USE transport_models_1d, ONLY: transport_model_1d
+  USE magnetic_geometry_state, ONLY: magnetic_geometry_cache
   USE analytical, only: analytical_solution
 
   IMPLICIT NONE
@@ -527,6 +528,8 @@ CONTAINS
   REAL*8                    :: Bmod_nod(refElPol%Nfacenodes),b_nod(refElPol%Nfacenodes,3)
   REAL*8                    :: xyg(refElPol%Ngauss1d,2),xyder(refElPol%Ngauss1d,2)
   REAL*8                    :: Bmod(refElPol%Ngauss1d),b(refElPol%Ngauss1d,3), psig(refElPol%Ngauss1d), rho_pol_norm(refElPol%Ngauss1d)
+  REAL*8                    :: topology_normal(refElPol%Ngauss1d,2)
+  INTEGER                   :: topology_region(refElPol%Ngauss1d)
   REAL*8                    :: ufg(refElPol%Ngauss1d,phys%neq),qfg(refElPol%Ngauss1d,phys%neq*2)
   REAL*8                    :: ueg(refElPol%Ngauss1d,phys%neq)
   REAL*8                    :: upg(refElPol%Ngauss1d,phys%npv),uexpg(refElPol%Ngauss1d,phys%npv)
@@ -677,6 +680,13 @@ CONTAINS
     ! Normalized magnetic flux at Gauss points: PSI
      psig = MATMUL(refElPol%N1d,psifl)
      rho_pol_norm = SQRT(MAX(psig,1.e-10))
+     topology_normal = 0.d0
+     topology_region = 0
+     IF (magnetic_geometry_cache%is_initialized) THEN
+       rho_pol_norm = magnetic_geometry_cache%face_rho(:,ifl,iel)
+       topology_normal = magnetic_geometry_cache%face_normal(:,ifl,iel,:)
+       topology_region = magnetic_geometry_cache%face_region(:,ifl,iel)
+     ENDIF
 
     ! q_cylicdrical and omega
 
@@ -696,7 +706,8 @@ CONTAINS
     ENDIF
 
     IF (switch%transport_1d) THEN
-      CALL transport_model_1d%apply_1D_diffusion(rho_pol_norm,diff_iso_fac,diff_ani_fac)
+      CALL transport_model_1d%apply_1D_diffusion(rho_pol_norm,diff_iso_fac,&
+        diff_ani_fac,topology_region)
     ENDIF
 
     if (save_tau) then
@@ -1273,18 +1284,22 @@ CONTAINS
 #ifndef SAVEFLUX
 #ifndef DKLINEARIZED
         CALL assembly_bohm_bc(iel,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,NiNi,Ni,qfg(g,:),&
-          &ufg(g,:),upg(g,:),ueg(g,:),b(g,1:2),psig(g),n_g,tau_stab,setval,dcs_du,delta,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),ntang)
+          &ufg(g,:),upg(g,:),ueg(g,:),b(g,1:2),rho_pol_norm(g),n_g,tau_stab,setval,dcs_du,delta,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),ntang,&
+          &topology_region=topology_region(g),outward_normal=topology_normal(g,:))
 #else
         CALL assembly_bohm_bc(iel,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,NiNi,Ni,qfg(g,:),&
-          &ufg(g,:),upg(g,:),ueg(g,:),b(g,1:2),psig(g),q_cyl(g),xyg(g,:),n_g,tau_stab,setval,dcs_du,delta,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),ntang)
+          &ufg(g,:),upg(g,:),ueg(g,:),b(g,1:2),rho_pol_norm(g),q_cyl(g),xyg(g,:),n_g,tau_stab,setval,dcs_du,delta,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),ntang,&
+          &topology_region=topology_region(g),outward_normal=topology_normal(g,:))
 #endif
 #else
 #ifndef DKLINEARIZED
         CALL assembly_bohm_bc(iel,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,NiNi,Ni,qfg(g,:),&
-          &ufg(g,:),upg(g,:),ueg(g,:),b(g,1:2),psig(g),n_g,tau_stab,setval,dcs_du,delta,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),dline,ntang,flgflux_pump,flgflux_puff,flgflux_parallel,flgflux_perpendicular,flgflux_pinch,flgflux_neutral,flgflux_numerical)
+          &ufg(g,:),upg(g,:),ueg(g,:),b(g,1:2),rho_pol_norm(g),n_g,tau_stab,setval,dcs_du,delta,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),dline,ntang,flgflux_pump,flgflux_puff,flgflux_parallel,flgflux_perpendicular,flgflux_pinch,flgflux_neutral,flgflux_numerical,&
+          &topology_region=topology_region(g),outward_normal=topology_normal(g,:))
 #else
         CALL assembly_bohm_bc(iel,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,NiNi,Ni,qfg(g,:),&
-        &ufg(g,:),upg(g,:),ueg(g,:),b(g,1:2),psig(g),q_cyl(g),xyg(g,:),n_g,tau_stab,setval,dcs_du,delta,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),dline,ntang,flgflux_pump,flgflux_puff,flgflux_parallel,flgflux_perpendicular,flgflux_pinch,flgflux_neutral,flgflux_numerical)
+        &ufg(g,:),upg(g,:),ueg(g,:),b(g,1:2),rho_pol_norm(g),q_cyl(g),xyg(g,:),n_g,tau_stab,setval,dcs_du,delta,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),dline,ntang,flgflux_pump,flgflux_puff,flgflux_parallel,flgflux_perpendicular,flgflux_pinch,flgflux_neutral,flgflux_numerical,&
+        &topology_region=topology_region(g),outward_normal=topology_normal(g,:))
 #endif
         !summing conribution from each part of the face
         faceflux_pump = faceflux_pump+flgflux_pump
@@ -1840,19 +1855,21 @@ CONTAINS
   !*********************************
 #ifndef SAVEFLUX
 #ifndef DKLINEARIZED
-    SUBROUTINE assembly_bohm_bc(iel,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,NiNi,Ni,qfg,ufg,upfg,uefg,bg,psig,ng,tau,setval,dcs_du,delta,diffiso,diffani,ntang)
+    SUBROUTINE assembly_bohm_bc(iel,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,NiNi,Ni,qfg,ufg,upfg,uefg,bg,rho,ng,tau,setval,dcs_du,delta,diffiso,diffani,ntang,topology_region,outward_normal)
 #else
-    SUBROUTINE assembly_bohm_bc(iel,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,NiNi,Ni,qfg,ufg,upfg,uefg,bg,psig,q_cyl,xyf,ng,tau,setval,dcs_du,delta,diffiso,diffani,ntang)
+    SUBROUTINE assembly_bohm_bc(iel,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,NiNi,Ni,qfg,ufg,upfg,uefg,bg,rho,q_cyl,xyf,ng,tau,setval,dcs_du,delta,diffiso,diffani,ntang,topology_region,outward_normal)
 #endif
 #else
 #ifndef DKLINEARIZED
-    SUBROUTINE assembly_bohm_bc(iel,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,NiNi,Ni,qfg,ufg,upfg,uefg,bg,psig,ng,tau,setval,dcs_du,delta,diffiso,diffani,dline,ntang,flgflux_pump,flgflux_puff,flgflux_parallel,flgflux_perpendicular,flgflux_pinch,flgflux_neutral,flgflux_numerical)
+    SUBROUTINE assembly_bohm_bc(iel,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,NiNi,Ni,qfg,ufg,upfg,uefg,bg,rho,ng,tau,setval,dcs_du,delta,diffiso,diffani,dline,ntang,flgflux_pump,flgflux_puff,flgflux_parallel,flgflux_perpendicular,flgflux_pinch,flgflux_neutral,flgflux_numerical,topology_region,outward_normal)
 #else
-    SUBROUTINE assembly_bohm_bc(iel,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,NiNi,Ni,qfg,ufg,upfg,uefg,bg,psig,q_cyl,xyf,ng,tau,setval,dcs_du,delta,diffiso,diffani,dline,ntang,flgflux_pump,flgflux_puff,flgflux_parallel,flgflux_perpendicular,flgflux_pinch,flgflux_neutral,flgflux_numerical)
+    SUBROUTINE assembly_bohm_bc(iel,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,NiNi,Ni,qfg,ufg,upfg,uefg,bg,rho,q_cyl,xyf,ng,tau,setval,dcs_du,delta,diffiso,diffani,dline,ntang,flgflux_pump,flgflux_puff,flgflux_parallel,flgflux_perpendicular,flgflux_pinch,flgflux_neutral,flgflux_numerical,topology_region,outward_normal)
 #endif
 #endif
     integer*4        :: iel,ind_asf(:),ind_ash(:),ind_ff(:),ind_fe(:),ind_fg(:),bc,delta
-    real*8           :: NiNi(:,:),Ni(:),ufg(:),upfg(:),uefg(:),bg(:),psig,ng(:),tau(:,:),setval,dcs_du(:)
+    real*8           :: NiNi(:,:),Ni(:),ufg(:),upfg(:),uefg(:),bg(:),rho,ng(:),tau(:,:),setval,dcs_du(:)
+    integer,intent(IN),optional :: topology_region
+    real*8,intent(IN),optional :: outward_normal(:)
     real*8           :: diffiso(:,:),diffani(:,:)
     logical          :: ntang
     real*8           :: qfg(:)
@@ -2024,7 +2041,8 @@ CONTAINS
       ! Jacobian matrix for pinch part
       APinch = 0.d0
       IF (switch%transport_1d) THEN
-        CALL transport_model_1d%compute_1D_pinch_matrix(bg,SQRT(MAX(psig,0.d0)),APinch)
+        CALL transport_model_1d%compute_1D_pinch_matrix(bg,rho,APinch,&
+          topology_region,outward_normal)
       ENDIF
 
         gmi = dot_PRODUCT(MATMUL(Qpr,Vveci),bg)  ! scalar

--- a/src/HDG/hdg_BC.f90
+++ b/src/HDG/hdg_BC.f90
@@ -1868,8 +1868,8 @@ CONTAINS
 #endif
     integer*4        :: iel,ind_asf(:),ind_ash(:),ind_ff(:),ind_fe(:),ind_fg(:),bc,delta
     real*8           :: NiNi(:,:),Ni(:),ufg(:),upfg(:),uefg(:),bg(:),rho,ng(:),tau(:,:),setval,dcs_du(:)
-    integer,intent(IN),optional :: topology_region
-    real*8,intent(IN),optional :: outward_normal(:)
+    integer,intent(IN)         :: topology_region
+    real*8,intent(IN)          :: outward_normal(:)
     real*8           :: diffiso(:,:),diffani(:,:)
     logical          :: ntang
     real*8           :: qfg(:)

--- a/src/HDG/hdg_ComputeJacobian.f90
+++ b/src/HDG/hdg_ComputeJacobian.f90
@@ -2252,8 +2252,8 @@ CONTAINS
 #endif
         REAL*8,INTENT(inout)      :: Auq(:,:,:),Auu(:,:,:),rhs(:,:)
         REAL*8,INTENT(IN)         :: b3(:),rho,divb,drift(:),f(:),ktis(:)
-        INTEGER, INTENT(IN), OPTIONAL :: topology_region
-        REAL*8, INTENT(IN), OPTIONAL :: outward_normal(:)
+        INTEGER, INTENT(IN)           :: topology_region
+        REAL*8, INTENT(IN)            :: outward_normal(:)
 #ifdef KEQUATION
     real*8,intent(IN)         :: btor,gradBtor(:), omega, q_cyl,xy(:)
 #ifdef DKLINEARIZED
@@ -3004,8 +3004,8 @@ ENDIF
 #endif
       integer*4,intent(IN)      :: iel,ind_asf(:),ind_ash(:),ind_ff(:),ind_fe(:),ind_fg(:)
       real*8,intent(IN)         :: b3(:),n(:), rho
-      integer,intent(IN),optional :: topology_region
-      real*8,intent(IN),optional :: outward_normal(:)
+      integer,intent(IN)         :: topology_region
+      real*8,intent(IN)          :: outward_normal(:)
       real*8,intent(IN)         :: diffiso(:,:),diffani(:,:)
       real*8,intent(IN)         :: NNif(:,:),Nif(:),Nfbn(:)
       real*8,intent(IN)         :: uf(:)
@@ -3492,8 +3492,8 @@ ENDIF
       integer*4,intent(IN)      :: iel,ind_asf(:),ind_ash(:),ind_ff(:),ind_fe(:),ind_fg(:)
       logical                   :: isdir
       real*8,intent(IN)         :: b3(:),n(:), rho
-      integer,intent(IN),optional :: topology_region
-      real*8,intent(IN),optional :: outward_normal(:)
+      integer,intent(IN)         :: topology_region
+      real*8,intent(IN)          :: outward_normal(:)
       real*8,intent(IN)         :: diffiso(:,:),diffani(:,:)
       real*8,intent(IN)         :: NNif(:,:),Nif(:),Nfbn(:)
       real*8,intent(IN)         :: uf(:)

--- a/src/HDG/hdg_ComputeJacobian.f90
+++ b/src/HDG/hdg_ComputeJacobian.f90
@@ -12,6 +12,7 @@ SUBROUTINE HDG_computeJacobian()
   USE analytical, only: body_force, analytical_solution
   USE physics
   USE transport_models_1d, ONLY: transport_model_1d
+  USE magnetic_geometry_state, ONLY: magnetic_geometry_cache
   USE hdg_limitingtechniques, ONLY:HDG_ShockCapturing
 
   IMPLICIT NONE
@@ -1346,6 +1347,8 @@ CONTAINS
       REAL*8                        :: iJ11(Ng2d),iJ12(Ng2d)
       REAL*8                        :: iJ21(Ng2d),iJ22(Ng2d)
       REAL*8                        :: fluxg(Ng2d),max_flux2D,min_flux2D, Psig(Ng2d),rho_pol_norm(Ng2d)
+      REAL*8                        :: topology_normal(Ng2d,2)
+      INTEGER                       :: topology_region(Ng2d)
       INTEGER*4,DIMENSION(Npel)     :: ind_ass,ind_asq
       REAL*8                        :: ktis(time%tis + 1)
       REAL*8,DIMENSION(Npel)        :: Ni,Nxg,Nyg,NNbb,Nx_ax
@@ -1420,6 +1423,13 @@ CONTAINS
     ! Normalized magnetic flux at Gauss points: PSI
       Psig = MATMUL(refElPol%N2D,psiel)
       rho_pol_norm = SQRT(MAX(Psig,1.e-10))
+      topology_normal = 0.d0
+      topology_region = 0
+      IF (magnetic_geometry_cache%is_initialized) THEN
+        rho_pol_norm = magnetic_geometry_cache%volume_rho(:,iel)
+        topology_normal = magnetic_geometry_cache%volume_normal(:,iel,:)
+        topology_region = magnetic_geometry_cache%volume_region(:,iel)
+      ENDIF
 
     ! toroidal current at Gauss points
     IF (switch%ohmicsrc) THEN
@@ -1453,7 +1463,8 @@ CONTAINS
     ENDIF
 
     IF (switch%transport_1d) THEN
-      CALL transport_model_1d%apply_1D_diffusion(rho_pol_norm,diff_iso_vol,diff_ani_vol)
+      CALL transport_model_1d%apply_1D_diffusion(rho_pol_norm,diff_iso_vol,&
+        diff_ani_vol,topology_region)
     ENDIF
 
 
@@ -1696,13 +1707,15 @@ CONTAINS
          gradbtor(2) = dot_PRODUCT(Nyg,b_tor_nod)
 #endif
 #ifndef KEQUATION
-      CALL assemblyVolumeContribution(Auq,Auu,rhs,b(g,:),Psig(g),divbg,driftg,force(g,:),&
+      CALL assemblyVolumeContribution(Auq,Auu,rhs,b(g,:),rho_pol_norm(g),divbg,driftg,force(g,:),&
         &ktis,diff_iso_vol(:,:,g),diff_ani_vol(:,:,g),Ni,NNi,Nxyzg,NNxy,NxyzNi,NNbb,upg(g,:),&
-        &ueg(g,:),qeg(g,:),u0eg(g,:,:),Jtor(g))
+        &ueg(g,:),qeg(g,:),u0eg(g,:,:),Jtor(g),topology_region=topology_region(g),&
+        &outward_normal=topology_normal(g,:))
 #else
-      CALL assemblyVolumeContribution(Auq,Auu,rhs,b(g,:),Psig(g),divbg,driftg,b_tor(g),gradbtor,omega(g),q_cyl(g),force(g,:),&
+      CALL assemblyVolumeContribution(Auq,Auu,rhs,b(g,:),rho_pol_norm(g),divbg,driftg,b_tor(g),gradbtor,omega(g),q_cyl(g),force(g,:),&
         &ktis,diff_iso_vol(:,:,g),diff_ani_vol(:,:,g),Ni,NNi,Nxyzg,NNxy,NxyzNi,NNbb,upg(g,:),&
-        &ueg(g,:),qeg(g,:),u0eg(g,:,:),xy(g,:),Jtor(g))
+        &ueg(g,:),qeg(g,:),u0eg(g,:,:),xy(g,:),Jtor(g),topology_region=topology_region(g),&
+        &outward_normal=topology_normal(g,:))
 #endif
 
          IF (save_tau) THEN
@@ -1742,6 +1755,8 @@ CONTAINS
     real*8                    :: upgf(Ng1d,phys%npv)
     real*8                    :: tau(Neq,Neq),Vnng(Ndim)
     real*8                    :: Bmod_nod(Npfl),b_nod(Npfl,3),b(Ng1d,3),Bmod(Ng1d),Psig(Ng1d),rho_pol_norm(Ng1d)
+    real*8                    :: topology_normal(Ng1d,2)
+    integer                   :: topology_region(Ng1d)
     real*8                    :: diff_iso_fac(Neq,Neq,Ng1d),diff_ani_fac(Neq,Neq,Ng1d)
     real*8                    :: auxdiffsc(Ng1d)
     real*8                    :: q_cyl(Ng1d)
@@ -1792,6 +1807,13 @@ CONTAINS
     ! Normalaized magnetic flux at Gauss points: PSI
       Psig = MATMUL(refElPol%N1d,psifl)
       rho_pol_norm = SQRT(MAX(Psig,1.e-10))
+      topology_normal = 0.d0
+      topology_region = 0
+      IF (magnetic_geometry_cache%is_initialized) THEN
+        rho_pol_norm = magnetic_geometry_cache%face_rho(:,ifa,iel)
+        topology_normal = magnetic_geometry_cache%face_normal(:,ifa,iel,:)
+        topology_region = magnetic_geometry_cache%face_region(:,ifa,iel)
+      ENDIF
 
     ! Element solution at face Gauss points
       uefg = MATMUL(refElPol%N1D,uef)
@@ -1810,7 +1832,8 @@ CONTAINS
     ENDIF
 
     IF (switch%transport_1d) THEN
-      CALL transport_model_1d%apply_1D_diffusion(rho_pol_norm,diff_iso_fac,diff_ani_fac)
+      CALL transport_model_1d%apply_1D_diffusion(rho_pol_norm,diff_iso_fac,&
+        diff_ani_fac,topology_region)
     ENDIF
     if (save_tau) then
        indsave = (ifa - 1)*Ngauss + (/(i,i=1,Ngauss)/)
@@ -1866,11 +1889,13 @@ CONTAINS
 
 ! Assembly local contributions
 #ifdef DKLINEARIZED
-      CALL assemblyIntFacesContribution(iel,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,b(g,:),Psig(g),q_cyl(g),xyf(g,:),&
-      n_g,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),NNif,Nif,Nfbn,ufg(g,:),qfg(g,:),tau)
+      CALL assemblyIntFacesContribution(iel,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,b(g,:),rho_pol_norm(g),q_cyl(g),xyf(g,:),&
+      n_g,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),NNif,Nif,Nfbn,ufg(g,:),qfg(g,:),tau,&
+      topology_region=topology_region(g),outward_normal=topology_normal(g,:))
 #else
-      CALL assemblyIntFacesContribution(iel,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,b(g,:),Psig(g),&
-        n_g,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),NNif,Nif,Nfbn,ufg(g,:),qfg(g,:),tau)
+      CALL assemblyIntFacesContribution(iel,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,b(g,:),rho_pol_norm(g),&
+        n_g,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),NNif,Nif,Nfbn,ufg(g,:),qfg(g,:),tau,&
+        topology_region=topology_region(g),outward_normal=topology_normal(g,:))
 #endif
 
          IF (save_tau) THEN
@@ -1917,6 +1942,8 @@ CONTAINS
     real*8                    :: tau(Neq,Neq)
     real*8                    :: upgf(Ng1d,phys%npv)
     real*8                    :: Bmod_nod(Npfl),b_nod(Npfl,3),b(Ng1d,3),Bmod(Ng1d), Psig(Ng1d), rho_pol_norm(Ng1d)
+    real*8                    :: topology_normal(Ng1d,2)
+    integer                   :: topology_region(Ng1d)
     real*8                    :: diff_iso_fac(Neq,Neq,Ng1d),diff_ani_fac(Neq,Neq,Ng1d)
     real*8                    :: auxdiffsc(Ng1d)
     real*8                    :: Vnng(Ndim)
@@ -1954,6 +1981,13 @@ CONTAINS
     ! Normalaized magnetic flux at Gauss points: PSI
     Psig = MATMUL(refElPol%N1D,psifl)
     rho_pol_norm = SQRT(MAX(Psig,1.e-10))
+    topology_normal = 0.d0
+    topology_region = 0
+    IF (magnetic_geometry_cache%is_initialized) THEN
+      rho_pol_norm = magnetic_geometry_cache%face_rho(:,ifa,iel)
+      topology_normal = magnetic_geometry_cache%face_normal(:,ifa,iel,:)
+      topology_region = magnetic_geometry_cache%face_region(:,ifa,iel)
+    ENDIF
 
     ! Trace solution at face Gauss points
     xyf = MATMUL(refElPol%N1D,Xfl)
@@ -1988,7 +2022,8 @@ CONTAINS
     ENDIF
 
     IF (switch%transport_1d) THEN
-      CALL transport_model_1d%apply_1D_diffusion(rho_pol_norm,diff_iso_fac,diff_ani_fac)
+      CALL transport_model_1d%apply_1D_diffusion(rho_pol_norm,diff_iso_fac,&
+        diff_ani_fac,topology_region)
     ENDIF
 
     if (save_tau) then
@@ -2062,30 +2097,36 @@ CONTAINS
          IF (Mesh%boundaryFlag(Mesh%F(iel,ifa) - Mesh%Nintfaces) .EQ. 0) THEN
         ! Ghost face: assembly it as interior
 #ifndef DKLINEARIZED
-        CALL assemblyIntFacesContribution(iel,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,b(g,:),Psig(g),&
-          n_g,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),NNif,Nif,Nfbn,ufg(g,:),qfg(g,:),tau)
+        CALL assemblyIntFacesContribution(iel,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,b(g,:),rho_pol_norm(g),&
+          n_g,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),NNif,Nif,Nfbn,ufg(g,:),qfg(g,:),tau,&
+          topology_region=topology_region(g),outward_normal=topology_normal(g,:))
 
       ELSE
-        CALL assemblyExtFacesContribution(iel,isdir,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,b(g,:),Psig(g),&
-          n_g,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),NNif,Nif,Nfbn,ufg(g,:),qfg(g,:),tau)
+        CALL assemblyExtFacesContribution(iel,isdir,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,b(g,:),rho_pol_norm(g),&
+          n_g,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),NNif,Nif,Nfbn,ufg(g,:),qfg(g,:),tau,&
+          topology_region=topology_region(g),outward_normal=topology_normal(g,:))
       ENDIF
 #else
 
-        CALL assemblyIntFacesContribution(iel,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,b(g,:),,Psig(g),q_cyl(g),xyf(g,:),&
-        n_g,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),NNif,Nif,Nfbn,ufg(g,:),qfg(g,:),tau)
+        CALL assemblyIntFacesContribution(iel,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,b(g,:),rho_pol_norm(g),q_cyl(g),xyf(g,:),&
+        n_g,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),NNif,Nif,Nfbn,ufg(g,:),qfg(g,:),tau,&
+        topology_region=topology_region(g),outward_normal=topology_normal(g,:))
       ELSE
-        CALL assemblyExtFacesContribution(iel,isdir,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,b(g,:),Psig(g),q_cyl(g),xyf(g,:),&
-          n_g,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),NNif,Nif,Nfbn,ufg(g,:),qfg(g,:),tau)
+        CALL assemblyExtFacesContribution(iel,isdir,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,b(g,:),rho_pol_norm(g),q_cyl(g),xyf(g,:),&
+          n_g,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),NNif,Nif,Nfbn,ufg(g,:),qfg(g,:),tau,&
+          topology_region=topology_region(g),outward_normal=topology_normal(g,:))
       ENDIF
 #endif
 
 #else
 #ifndef DKLINEARIZED
-      CALL assemblyExtFacesContribution(iel,isdir,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,b(g,:),Psig(g),&
-        n_g,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),NNif,Nif,Nfbn,ufg(g,:),qfg(g,:),tau)
+      CALL assemblyExtFacesContribution(iel,isdir,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,b(g,:),rho_pol_norm(g),&
+        n_g,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),NNif,Nif,Nfbn,ufg(g,:),qfg(g,:),tau,&
+        topology_region=topology_region(g),outward_normal=topology_normal(g,:))
 #else
-      CALL assemblyExtFacesContribution(iel,isdir,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,b(g,:),Psig(g),q_cyl(g),xyf(g,:),&
-        n_g,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),NNif,Nif,Nfbn,ufg(g,:),qfg(g,:),tau)
+      CALL assemblyExtFacesContribution(iel,isdir,ind_asf,ind_ash,ind_ff,ind_fe,ind_fg,b(g,:),rho_pol_norm(g),q_cyl(g),xyf(g,:),&
+        n_g,diff_iso_fac(:,:,g),diff_ani_fac(:,:,g),NNif,Nif,Nfbn,ufg(g,:),qfg(g,:),tau,&
+        topology_region=topology_region(g),outward_normal=topology_normal(g,:))
 #endif
 
 #endif
@@ -2195,14 +2236,18 @@ CONTAINS
   !
   !********************************************************************
 #ifndef KEQUATION
-  SUBROUTINE assemblyVolumeContribution(Auq,Auu,rhs,b3,psi,divb,drift,f,&
-      &ktis,diffiso,diffani,Ni,NNi,Nxyzg,NNxy,NxyzNi,NNbb,upe,ue,qe,u0e,Jtor)
+  SUBROUTINE assemblyVolumeContribution(Auq,Auu,rhs,b3,rho,divb,drift,f,&
+      &ktis,diffiso,diffani,Ni,NNi,Nxyzg,NNxy,NxyzNi,NNbb,upe,ue,qe,u0e,Jtor,&
+      &topology_region,outward_normal)
 #else
-  SUBROUTINE assemblyVolumeContribution(Auq,Auu,rhs,b3,psi,divb,drift,btor,gradBtor,omega,q_cyl,f,&
-    &ktis,diffiso,diffani,Ni,NNi,Nxyzg,NNxy,NxyzNi,NNbb,upe,ue,qe,u0e,xy,Jtor)
+  SUBROUTINE assemblyVolumeContribution(Auq,Auu,rhs,b3,rho,divb,drift,btor,gradBtor,omega,q_cyl,f,&
+    &ktis,diffiso,diffani,Ni,NNi,Nxyzg,NNxy,NxyzNi,NNbb,upe,ue,qe,u0e,xy,Jtor,&
+    &topology_region,outward_normal)
 #endif
         REAL*8,INTENT(inout)      :: Auq(:,:,:),Auu(:,:,:),rhs(:,:)
-        REAL*8,INTENT(IN)         :: b3(:),psi,divb,drift(:),f(:),ktis(:)
+        REAL*8,INTENT(IN)         :: b3(:),rho,divb,drift(:),f(:),ktis(:)
+        INTEGER, INTENT(IN), OPTIONAL :: topology_region
+        REAL*8, INTENT(IN), OPTIONAL :: outward_normal(:)
 #ifdef KEQUATION
     real*8,intent(IN)         :: btor,gradBtor(:), omega, q_cyl,xy(:)
 #ifdef DKLINEARIZED
@@ -2287,7 +2332,8 @@ CONTAINS
     ! Jacobian for pinch term
     APinch = 0.d0
     IF (switch%transport_1d) THEN
-      CALL transport_model_1d%compute_1D_pinch_matrix(b,SQRT(MAX(psi,0.d0)),APinch)
+      CALL transport_model_1d%compute_1D_pinch_matrix(b,rho,APinch,&
+        topology_region,outward_normal)
     ENDIF
 
     ! Compute Q^T^(k-1)
@@ -2943,13 +2989,17 @@ ENDIF
 
 #ifdef DKLINEARIZED
   SUBROUTINE assemblyIntFacesContribution(iel,ind_asf,ind_ash,ind_ff,ind_fe,&
-    &ind_fg,b3,psi,q_cyl,xyf,n,diffiso,diffani,NNif,Nif,Nfbn,uf,qf,tau)
+    &ind_fg,b3,rho,q_cyl,xyf,n,diffiso,diffani,NNif,Nif,Nfbn,uf,qf,tau,&
+    &topology_region,outward_normal)
 #else
     SUBROUTINE assemblyIntFacesContribution(iel,ind_asf,ind_ash,ind_ff,ind_fe,&
-        &ind_fg,b3,psi,n,diffiso,diffani,NNif,Nif,Nfbn,uf,qf,tau)
+        &ind_fg,b3,rho,n,diffiso,diffani,NNif,Nif,Nfbn,uf,qf,tau,&
+        &topology_region,outward_normal)
 #endif
       integer*4,intent(IN)      :: iel,ind_asf(:),ind_ash(:),ind_ff(:),ind_fe(:),ind_fg(:)
-      real*8,intent(IN)         :: b3(:),n(:), psi
+      real*8,intent(IN)         :: b3(:),n(:), rho
+      integer,intent(IN),optional :: topology_region
+      real*8,intent(IN),optional :: outward_normal(:)
       real*8,intent(IN)         :: diffiso(:,:),diffani(:,:)
       real*8,intent(IN)         :: NNif(:,:),Nif(:),Nfbn(:)
       real*8,intent(IN)         :: uf(:)
@@ -3008,7 +3058,8 @@ ENDIF
       ! Jacobian for pinch term
       APinch = 0.d0
       IF (switch%transport_1d) THEN
-      CALL transport_model_1d%compute_1D_pinch_matrix(b,SQRT(MAX(psi,0.d0)),APinch)
+      CALL transport_model_1d%compute_1D_pinch_matrix(b,rho,APinch,&
+        topology_region,outward_normal)
     ENDIF
 
       ! Compute Q^T^(k-1)
@@ -3425,14 +3476,18 @@ ENDIF
 
 #ifdef DKLINEARIZED
     SUBROUTINE assemblyExtFacesContribution(iel,isdir,ind_asf,ind_ash,ind_ff,ind_fe,&
-      &ind_fg,b3,psi,q_cyl,xyf,n,diffiso,diffani,NNif,Nif,Nfbn,uf,qf,tau)
+      &ind_fg,b3,rho,q_cyl,xyf,n,diffiso,diffani,NNif,Nif,Nfbn,uf,qf,tau,&
+      &topology_region,outward_normal)
 #else
     SUBROUTINE assemblyExtFacesContribution(iel,isdir,ind_asf,ind_ash,ind_ff,ind_fe,&
-        &ind_fg,b3,psi,n,diffiso,diffani,NNif,Nif,Nfbn,uf,qf,tau)
+        &ind_fg,b3,rho,n,diffiso,diffani,NNif,Nif,Nfbn,uf,qf,tau,&
+        &topology_region,outward_normal)
 #endif
       integer*4,intent(IN)      :: iel,ind_asf(:),ind_ash(:),ind_ff(:),ind_fe(:),ind_fg(:)
       logical                   :: isdir
-      real*8,intent(IN)         :: b3(:),n(:), psi
+      real*8,intent(IN)         :: b3(:),n(:), rho
+      integer,intent(IN),optional :: topology_region
+      real*8,intent(IN),optional :: outward_normal(:)
       real*8,intent(IN)         :: diffiso(:,:),diffani(:,:)
       real*8,intent(IN)         :: NNif(:,:),Nif(:),Nfbn(:)
       real*8,intent(IN)         :: uf(:)
@@ -3490,7 +3545,8 @@ ENDIF
       ! Jacobian matrices Pinch
       APinch = 0.d0
       IF (switch%transport_1d) THEN
-      CALL transport_model_1d%compute_1D_pinch_matrix(b,SQRT(MAX(psi,0.d0)),APinch)
+      CALL transport_model_1d%compute_1D_pinch_matrix(b,rho,APinch,&
+        topology_region,outward_normal)
     ENDIF
 
       ! Compute Q^T^(k-1)

--- a/src/HDG/hdg_ComputeJacobian.f90
+++ b/src/HDG/hdg_ComputeJacobian.f90
@@ -12,7 +12,9 @@ SUBROUTINE HDG_computeJacobian()
   USE analytical, only: body_force, analytical_solution
   USE physics
   USE transport_models_1d, ONLY: transport_model_1d
-  USE magnetic_geometry_state, ONLY: magnetic_geometry_cache
+  USE magnetic_geometry_state, ONLY: magnetic_geometry_cache, &
+       toroidal_current_from_flux
+  USE magnetic_topology, ONLY: magnetic_region_core
   USE hdg_limitingtechniques, ONLY:HDG_ShockCapturing
 
   IMPLICIT NONE
@@ -1434,6 +1436,10 @@ CONTAINS
     ! toroidal current at Gauss points
     IF (switch%ohmicsrc) THEN
          Jtor = MATMUL(refElPol%N2D,Jtorel)
+         IF (toroidal_current_from_flux .AND. &
+              magnetic_geometry_cache%is_initialized) THEN
+            WHERE (topology_region /= magnetic_region_core) Jtor = 0.d0
+         ENDIF
     ELSE
       Jtor = 0.
     END IF

--- a/src/InOut/inout.f90
+++ b/src/InOut/inout.f90
@@ -17,7 +17,8 @@ MODULE in_out
   USE printutils
   USE magnetic_geometry_state, ONLY: magnetic_equilibrium, &
        magnetic_geometry_cache, poloidal_field_fit, &
-       set_restart_geometry_reference
+       set_restart_geometry_reference, toroidal_current_from_flux, &
+       toroidal_current_comparison
   USE magnetic_topology, ONLY: topology_limited, topology_lower_single_null, &
        lcfs_source_wall, lcfs_source_xpoint, magnetic_region_core, &
        magnetic_region_main_sol, magnetic_region_private_flux
@@ -863,7 +864,7 @@ CONTAINS
       INTEGER, INTENT(IN) :: region(:)
       REAL*8 :: point(2)
       REAL*8, ALLOCATABLE :: lcfs_contour(:, :)
-      CHARACTER(LEN=32) :: topology_name, source_name
+      CHARACTER(LEN=32) :: topology_name, source_name, jtor_source_name
 
       SELECT CASE (magnetic_equilibrium%topology_kind)
       CASE (topology_limited)
@@ -881,6 +882,13 @@ CONTAINS
       CASE DEFAULT
          source_name = 'unknown'
       END SELECT
+      IF (.NOT. switch%ohmicsrc) THEN
+         jtor_source_name = 'disabled'
+      ELSEIF (toroidal_current_from_flux) THEN
+         jtor_source_name = 'bicubic_psi'
+      ELSE
+         jtor_source_name = 'stored_hdf5'
+      ENDIF
 
       CALL HDF5_real_saving(magnetic_group_id, magnetic_equilibrium%psi_lcfs, &
            'psiSep')
@@ -935,8 +943,46 @@ CONTAINS
            'field_fit_alpha')
       CALL HDF5_real_saving(magnetic_group_id, poloidal_field_fit%relative_rms, &
            'field_fit_relative_rms')
+      CALL HDF5_real_saving(magnetic_group_id, poloidal_field_fit%applied_alpha, &
+           'field_applied_alpha')
+      CALL HDF5_real_saving(magnetic_group_id, &
+           poloidal_field_fit%applied_relative_rms, 'field_applied_relative_rms')
+      CALL HDF5_real_saving(magnetic_group_id, &
+           poloidal_field_fit%canonical_relative_difference, &
+           'field_alpha_canonical_relative_difference')
+      CALL HDF5_integer_saving(magnetic_group_id, &
+           poloidal_field_fit%convention_id, 'field_alpha_convention_id')
       CALL HDF5_integer_saving(magnetic_group_id, poloidal_field_fit%sample_count, &
            'field_fit_sample_count')
+      CALL HDF5_logical_saving(magnetic_group_id, toroidal_current_from_flux, &
+           'jtor_from_flux')
+      CALL HDF5_string_saving(magnetic_group_id, TRIM(jtor_source_name), &
+           'jtor_source')
+      CALL HDF5_logical_saving(magnetic_group_id, &
+           toroidal_current_comparison%is_valid, 'jtor_comparison_valid')
+      CALL HDF5_integer_saving(magnetic_group_id, &
+           toroidal_current_comparison%applied_sign, 'jtor_applied_sign')
+      CALL HDF5_real_saving(magnetic_group_id, &
+           toroidal_current_comparison%core_raw_relative_l2, &
+           'jtor_core_raw_relative_l2')
+      CALL HDF5_real_saving(magnetic_group_id, &
+           toroidal_current_comparison%core_relative_l2, &
+           'jtor_core_relative_l2')
+      CALL HDF5_real_saving(magnetic_group_id, &
+           toroidal_current_comparison%core_norm_ratio, &
+           'jtor_core_norm_ratio')
+      CALL HDF5_real_saving(magnetic_group_id, &
+           toroidal_current_comparison%core_best_scale, &
+           'jtor_core_best_scale')
+      CALL HDF5_real_saving(magnetic_group_id, &
+           toroidal_current_comparison%stored_outside_core_relative_l2, &
+           'jtor_stored_outside_core_relative_l2')
+      CALL HDF5_integer_saving(magnetic_group_id, &
+           toroidal_current_comparison%core_sample_count, &
+           'jtor_comparison_core_sample_count')
+      CALL HDF5_integer_saving(magnetic_group_id, &
+           toroidal_current_comparison%outside_sample_count, &
+           'jtor_comparison_outside_sample_count')
       CALL HDF5_integer_saving(magnetic_group_id, magnetic_equilibrium%generation, &
            'equilibrium_generation')
       CALL HDF5_integer_saving(magnetic_group_id, magnetic_geometry_cache%generation, &

--- a/src/InOut/inout.f90
+++ b/src/InOut/inout.f90
@@ -15,6 +15,12 @@ MODULE in_out
   USE GLOBALS
   USE MPI_OMP
   USE printutils
+  USE magnetic_geometry_state, ONLY: magnetic_equilibrium, &
+       magnetic_geometry_cache, poloidal_field_fit, &
+       set_restart_geometry_reference
+  USE magnetic_topology, ONLY: topology_limited, topology_lower_single_null, &
+       lcfs_source_wall, lcfs_source_xpoint, magnetic_region_core, &
+       magnetic_region_main_sol, magnetic_region_private_flux
 
   IMPLICIT NONE
 
@@ -487,7 +493,8 @@ CONTAINS
   SUBROUTINE HDF5_save_solution(fname)
 
 #ifdef PARALL
-    USE communications, ONLY: gather_mesh, gather_solution, gather_additional, gather_magnetic_field, gather_nodal_values
+    USE communications, ONLY: gather_mesh, gather_solution, gather_additional, &
+         gather_magnetic_field, gather_nodal_values, gather_magnetic_geometry
 #endif
     IMPLICIT NONE
 
@@ -503,11 +510,14 @@ CONTAINS
     INTEGER, POINTER        :: T_glob(:,:), Tb_glob(:,:), extfaces_glob(:,:), intfaces_glob(:,:), boundaryFlag_glob(:), periodic_faces_glob(:), F_glob(:,:), N_glob(:,:), face_info_glob(:,:), Tlin_glob(:,:), flag_elems_sc_glob(:)
     REAL*8, POINTER         :: u_tilde_glob(:), u_glob(:), q_glob(:), magnetic_psi_glob(:), magnetic_flux_glob(:), Jtor_glob(:), elemSize_glob(:), scdiff_nodes_glob(:,:)
     REAL*8, POINTER         :: X_glob(:,:), B_glob(:,:), Bperturb_glob(:,:)
+    REAL*8, POINTER         :: rho_glob(:), topology_normal_glob(:, :)
+    INTEGER, POINTER        :: topology_region_glob(:)
     REAL*8, POINTER         :: external_heating_ions_glob(:), external_heating_electrons_glob(:)
 
     NULLIFY(T_glob, Tb_glob, extfaces_glob, intfaces_glob, boundaryFlag_glob, periodic_faces_glob, F_glob, N_glob, face_info_glob, Tlin_glob, flag_elems_sc_glob)
     NULLIFY(u_tilde_glob, u_glob, q_glob, magnetic_psi_glob, magnetic_flux_glob, Jtor_glob, elemSize_glob, scdiff_nodes_glob)
     NULLIFY(X_glob, B_glob, Bperturb_glob)
+    NULLIFY(rho_glob, topology_normal_glob, topology_region_glob)
     NULLIFY(external_heating_ions_glob, external_heating_electrons_glob)
 
 #endif
@@ -575,6 +585,10 @@ CONTAINS
     ENDIF
     IF (switch%ripple) THEN
        CALL HDF5_array2D_saving(group_id1, magn%coils_ripple, SIZE(magn%coils_ripple, 1), SIZE(magn%coils_ripple, 2), 'coils_ripple')
+    ENDIF
+    IF (magnetic_geometry_cache%is_initialized) THEN
+       CALL save_magnetic_geometry(group_id1, magnetic_geometry_cache%nodal_rho, &
+            magnetic_geometry_cache%nodal_normal, magnetic_geometry_cache%nodal_region)
     ENDIF
     CALL HDF5_group_close(group_id1, ierr)
 
@@ -669,6 +683,11 @@ CONTAINS
        ELSE
           CALL gather_magnetic_field(Mesh_in = Mesh, B_glob = B_glob, magnetic_flux_glob = magnetic_flux_glob, magnetic_psi_glob = magnetic_psi_glob)
        ENDIF
+    ENDIF
+
+    IF (magnetic_geometry_cache%is_initialized) THEN
+       CALL gather_magnetic_geometry(Mesh, rho_glob, topology_normal_glob, &
+            topology_region_glob)
     ENDIF
 
     IF (switch%external_heating) THEN
@@ -790,6 +809,10 @@ CONTAINS
        IF (switch%shockcp .EQ. 3) THEN
           CALL HDF5_array2D_saving(group_id1, scdiff_nodes_glob, SIZE(scdiff_nodes_glob, 1), SIZE(scdiff_nodes_glob, 2), 'scdiff_nodes')
        END IF
+       IF (magnetic_geometry_cache%is_initialized) THEN
+          CALL save_magnetic_geometry(group_id1, rho_glob, &
+               topology_normal_glob, topology_region_glob)
+       ENDIF
        CALL HDF5_group_close(group_id1, ierr)
 
     END IF
@@ -820,6 +843,10 @@ CONTAINS
       DEALLOCATE(scdiff_nodes_glob)
       NULLIFY(scdiff_nodes_glob)
     ENDIF
+    IF (ASSOCIATED(rho_glob)) THEN
+       DEALLOCATE(rho_glob, topology_normal_glob, topology_region_glob)
+       NULLIFY(rho_glob, topology_normal_glob, topology_region_glob)
+    ENDIF
 #endif
 
   IF(MPIvar%glob_id .eq. 0) THEN
@@ -829,6 +856,92 @@ CONTAINS
     PRINT *, '        '
   ENDIF
   CONTAINS
+
+    SUBROUTINE save_magnetic_geometry(magnetic_group_id, rho, normal, region)
+      INTEGER(HID_T), INTENT(IN) :: magnetic_group_id
+      REAL*8, INTENT(IN) :: rho(:), normal(:, :)
+      INTEGER, INTENT(IN) :: region(:)
+      REAL*8 :: point(2)
+      REAL*8, ALLOCATABLE :: lcfs_contour(:, :)
+      CHARACTER(LEN=32) :: topology_name, source_name
+
+      SELECT CASE (magnetic_equilibrium%topology_kind)
+      CASE (topology_limited)
+         topology_name = 'limited'
+      CASE (topology_lower_single_null)
+         topology_name = 'lower_single_null'
+      CASE DEFAULT
+         topology_name = 'unknown'
+      END SELECT
+      SELECT CASE (magnetic_equilibrium%lcfs_source)
+      CASE (lcfs_source_wall)
+         source_name = 'wall_contact'
+      CASE (lcfs_source_xpoint)
+         source_name = 'x_point'
+      CASE DEFAULT
+         source_name = 'unknown'
+      END SELECT
+
+      CALL HDF5_real_saving(magnetic_group_id, magnetic_equilibrium%psi_lcfs, &
+           'psiSep')
+      CALL HDF5_real_saving(magnetic_group_id, magnetic_equilibrium%psi_sep_input, &
+           'psiSep_input')
+      CALL HDF5_real_saving(magnetic_group_id, magnetic_equilibrium%psi_axis, &
+           'psi_axis')
+      CALL HDF5_string_saving(magnetic_group_id, TRIM(topology_name), 'topology')
+      CALL HDF5_integer_saving(magnetic_group_id, &
+           magnetic_equilibrium%topology_kind, 'topology_id')
+      CALL HDF5_string_saving(magnetic_group_id, TRIM(source_name), 'lcfs_source')
+      CALL HDF5_integer_saving(magnetic_group_id, &
+           magnetic_equilibrium%lcfs_source, 'lcfs_source_id')
+
+      point = (/magnetic_equilibrium%r_axis, magnetic_equilibrium%z_axis/)*phys%lscale
+      CALL HDF5_array1D_saving(magnetic_group_id, point, 2, 'axis')
+      CALL HDF5_real_saving(magnetic_group_id, point(1), 'r_axis')
+      CALL HDF5_real_saving(magnetic_group_id, point(2), 'z_axis')
+      point = (/magnetic_equilibrium%r_wall_contact, &
+           magnetic_equilibrium%z_wall_contact/)*phys%lscale
+      CALL HDF5_array1D_saving(magnetic_group_id, point, 2, 'wall_contact')
+      point = (/magnetic_equilibrium%r_xpoint, &
+           magnetic_equilibrium%z_xpoint/)*phys%lscale
+      CALL HDF5_array1D_saving(magnetic_group_id, point, 2, 'x_point')
+      CALL HDF5_real_saving(magnetic_group_id, &
+           magnetic_equilibrium%a_minor*phys%lscale, 'a_minor')
+
+      ALLOCATE(lcfs_contour(SIZE(magnetic_equilibrium%lcfs_r), 2))
+      lcfs_contour(:, 1) = magnetic_equilibrium%lcfs_r*phys%lscale
+      lcfs_contour(:, 2) = magnetic_equilibrium%lcfs_z*phys%lscale
+      CALL HDF5_array2D_saving(magnetic_group_id, lcfs_contour, &
+           SIZE(lcfs_contour, 1), 2, 'lcfs_contour')
+      DEALLOCATE(lcfs_contour)
+
+      CALL HDF5_array1D_saving(magnetic_group_id, rho, SIZE(rho), 'rho_pol_norm')
+      CALL HDF5_array2D_saving(magnetic_group_id, normal, SIZE(normal, 1), 2, &
+           'topology_normal')
+      CALL HDF5_array1D_saving_int(magnetic_group_id, region, SIZE(region), &
+           'topology_region')
+      CALL HDF5_integer_saving(magnetic_group_id, magnetic_region_core, &
+           'region_id_core')
+      CALL HDF5_integer_saving(magnetic_group_id, magnetic_region_main_sol, &
+           'region_id_main_sol')
+      CALL HDF5_integer_saving(magnetic_group_id, magnetic_region_private_flux, &
+           'region_id_private_flux')
+
+      CALL HDF5_logical_saving(magnetic_group_id, input%compute_from_flux, &
+           'compute_from_flux')
+      CALL HDF5_logical_saving(magnetic_group_id, poloidal_field_fit%is_valid, &
+           'field_fit_valid')
+      CALL HDF5_real_saving(magnetic_group_id, poloidal_field_fit%alpha, &
+           'field_fit_alpha')
+      CALL HDF5_real_saving(magnetic_group_id, poloidal_field_fit%relative_rms, &
+           'field_fit_relative_rms')
+      CALL HDF5_integer_saving(magnetic_group_id, poloidal_field_fit%sample_count, &
+           'field_fit_sample_count')
+      CALL HDF5_integer_saving(magnetic_group_id, magnetic_equilibrium%generation, &
+           'equilibrium_generation')
+      CALL HDF5_integer_saving(magnetic_group_id, magnetic_geometry_cache%generation, &
+           'cache_generation')
+    END SUBROUTINE save_magnetic_geometry
 
     !**********************************************************************
     ! Save the identity of the executable that produced this solution
@@ -1626,6 +1739,7 @@ CONTAINS
     CALL HDF5_array1D_reading(group_id, sol%q, 'q')
     CALL HDF5_group_close(group_id, ierr)
 
+    CALL load_restart_geometry_reference(file_id)
     CALL HDF5_close(file_id)
 #endif
 
@@ -1673,6 +1787,33 @@ CONTAINS
     END IF
 
   ENDSUBROUTINE HDF5_load_solution
+
+  SUBROUTINE load_restart_geometry_reference(file_id)
+    INTEGER(HID_T), INTENT(IN) :: file_id
+    INTEGER(HID_T) :: magnetic_group_id
+    INTEGER :: ierr
+    LOGICAL :: exists
+    REAL*8 :: psi_lcfs, r_axis, z_axis, a_minor
+
+    CALL H5Lexists_f(file_id, 'magnetic/psiSep', exists, ierr)
+    IF (ierr /= 0 .OR. .NOT. exists) RETURN
+    CALL H5Lexists_f(file_id, 'magnetic/r_axis', exists, ierr)
+    IF (ierr /= 0 .OR. .NOT. exists) RETURN
+    CALL H5Lexists_f(file_id, 'magnetic/z_axis', exists, ierr)
+    IF (ierr /= 0 .OR. .NOT. exists) RETURN
+    CALL H5Lexists_f(file_id, 'magnetic/a_minor', exists, ierr)
+    IF (ierr /= 0 .OR. .NOT. exists) RETURN
+    CALL HDF5_group_open(file_id, 'magnetic', magnetic_group_id, ierr)
+    IF (ierr /= 0) RETURN
+    CALL HDF5_real_reading(magnetic_group_id, psi_lcfs, 'psiSep')
+    CALL HDF5_real_reading(magnetic_group_id, r_axis, 'r_axis')
+    CALL HDF5_real_reading(magnetic_group_id, z_axis, 'z_axis')
+    CALL HDF5_real_reading(magnetic_group_id, a_minor, 'a_minor')
+    CALL HDF5_group_close(magnetic_group_id, ierr)
+    IF (ierr == 0) THEN
+       CALL set_restart_geometry_reference(psi_lcfs, r_axis, z_axis, a_minor)
+    ENDIF
+  END SUBROUTINE load_restart_geometry_reference
 
   !**********************************************************************
   ! Save HDG matrix (CSR) in HDF5 file format

--- a/src/InOut/read_input.f90
+++ b/src/InOut/read_input.f90
@@ -565,6 +565,8 @@ SUBROUTINE READ_input()
      PRINT *, '                - rho_core (transport model):            ', transport_model_input%rho_core
      PRINT *, '                - rho_edge (transport model):            ', transport_model_input%rho_edge
      PRINT *, '                - rho_diffusion_model_max (transport model):       ', transport_model_input%rho_diffusion_model_max
+     PRINT *, '                - transport_region_policy (transport model):       ', &
+          TRIM(transport_model_input%transport_region_policy)
      PRINT *, '                - c_bohm_i (transport model):           ', transport_model_input%c_bohm_i
      PRINT *, '                - c_gyrobohm_i (transport model):       ', transport_model_input%c_gyrobohm_i
      PRINT *, '                - c_bohm_e (transport model):           ', transport_model_input%c_bohm_e
@@ -679,11 +681,18 @@ SUBROUTINE read_transport_model_input()
   INTEGER :: utransport, ios
   REAL*8 :: rho_core, rho_edge, rho_diffusion_model_max, c_bohm_i, c_gyrobohm_i, c_bohm_e, c_gyrobohm_e, c_bohm_n, prandtl, c_pinch, nu_th, vpinch_const_phys, rho_pinch_axis_width, rho_pinch_model_max, rho_pinch_edge_width, rho_blend_width, diff_n_min_phys, diff_u_min_phys, diff_e_min_phys, diff_ee_min_phys
   INTEGER :: pinch_model
-  NAMELIST /TRANSPORT_MODEL_1D_LST/ rho_core, rho_edge, rho_diffusion_model_max, c_bohm_i, c_gyrobohm_i, c_bohm_e, c_gyrobohm_e, c_bohm_n, prandtl, pinch_model, c_pinch, nu_th, vpinch_const_phys, rho_pinch_axis_width, rho_pinch_model_max, rho_pinch_edge_width, rho_blend_width, diff_n_min_phys, diff_u_min_phys, diff_e_min_phys, diff_ee_min_phys
+  CHARACTER(LEN=32) :: transport_region_policy
+  NAMELIST /TRANSPORT_MODEL_1D_LST/ rho_core, rho_edge, rho_diffusion_model_max, &
+       transport_region_policy, c_bohm_i, c_gyrobohm_i, c_bohm_e, c_gyrobohm_e, &
+       c_bohm_n, prandtl, pinch_model, c_pinch, nu_th, vpinch_const_phys, &
+       rho_pinch_axis_width, rho_pinch_model_max, rho_pinch_edge_width, &
+       rho_blend_width, diff_n_min_phys, diff_u_min_phys, diff_e_min_phys, &
+       diff_ee_min_phys
 
   rho_core = transport_model_input%rho_core
   rho_edge = transport_model_input%rho_edge
   rho_diffusion_model_max = transport_model_input%rho_diffusion_model_max
+  transport_region_policy = transport_model_input%transport_region_policy
   c_bohm_i = transport_model_input%c_bohm_i
   c_gyrobohm_i = transport_model_input%c_gyrobohm_i
   c_bohm_e = transport_model_input%c_bohm_e
@@ -722,6 +731,7 @@ SUBROUTINE read_transport_model_input()
   transport_model_input%rho_core = rho_core
   transport_model_input%rho_edge = rho_edge
   transport_model_input%rho_diffusion_model_max = rho_diffusion_model_max
+  transport_model_input%transport_region_policy = TRIM(ADJUSTL(transport_region_policy))
   transport_model_input%c_bohm_i = c_bohm_i
   transport_model_input%c_gyrobohm_i = c_gyrobohm_i
   transport_model_input%c_bohm_e = c_bohm_e

--- a/src/InOut/read_input.f90
+++ b/src/InOut/read_input.f90
@@ -572,6 +572,8 @@ SUBROUTINE READ_input()
      PRINT *, '                - c_bohm_e (transport model):           ', transport_model_input%c_bohm_e
      PRINT *, '                - c_gyrobohm_e (transport model):       ', transport_model_input%c_gyrobohm_e
      PRINT *, '                - c_bohm_n (transport model):           ', transport_model_input%c_bohm_n
+     PRINT *, '                - c_bohm_n_rho_slope (transport model): ', &
+          transport_model_input%c_bohm_n_rho_slope
      PRINT *, '                - prandtl (transport model):            ', transport_model_input%prandtl
      PRINT *, '                - pinch_model (transport model):        ', transport_model_input%pinch_model
      PRINT *, '                - c_pinch (transport model):            ', transport_model_input%c_pinch
@@ -679,12 +681,13 @@ SUBROUTINE read_transport_model_input()
   IMPLICIT NONE
 
   INTEGER :: utransport, ios
-  REAL*8 :: rho_core, rho_edge, rho_diffusion_model_max, c_bohm_i, c_gyrobohm_i, c_bohm_e, c_gyrobohm_e, c_bohm_n, prandtl, c_pinch, nu_th, vpinch_const_phys, rho_pinch_axis_width, rho_pinch_model_max, rho_pinch_edge_width, rho_blend_width, diff_n_min_phys, diff_u_min_phys, diff_e_min_phys, diff_ee_min_phys
+  REAL*8 :: rho_core, rho_edge, rho_diffusion_model_max, c_bohm_i, c_gyrobohm_i, c_bohm_e, c_gyrobohm_e, c_bohm_n, c_bohm_n_rho_slope, prandtl, c_pinch, nu_th, vpinch_const_phys, rho_pinch_axis_width, rho_pinch_model_max, rho_pinch_edge_width, rho_blend_width, diff_n_min_phys, diff_u_min_phys, diff_e_min_phys, diff_ee_min_phys
   INTEGER :: pinch_model
   CHARACTER(LEN=32) :: transport_region_policy
   NAMELIST /TRANSPORT_MODEL_1D_LST/ rho_core, rho_edge, rho_diffusion_model_max, &
        transport_region_policy, c_bohm_i, c_gyrobohm_i, c_bohm_e, c_gyrobohm_e, &
-       c_bohm_n, prandtl, pinch_model, c_pinch, nu_th, vpinch_const_phys, &
+       c_bohm_n, c_bohm_n_rho_slope, prandtl, pinch_model, c_pinch, nu_th, &
+       vpinch_const_phys, &
        rho_pinch_axis_width, rho_pinch_model_max, rho_pinch_edge_width, &
        rho_blend_width, diff_n_min_phys, diff_u_min_phys, diff_e_min_phys, &
        diff_ee_min_phys
@@ -698,6 +701,7 @@ SUBROUTINE read_transport_model_input()
   c_bohm_e = transport_model_input%c_bohm_e
   c_gyrobohm_e = transport_model_input%c_gyrobohm_e
   c_bohm_n = transport_model_input%c_bohm_n
+  c_bohm_n_rho_slope = transport_model_input%c_bohm_n_rho_slope
   prandtl = transport_model_input%prandtl
   pinch_model = transport_model_input%pinch_model
   c_pinch = transport_model_input%c_pinch
@@ -737,6 +741,7 @@ SUBROUTINE read_transport_model_input()
   transport_model_input%c_bohm_e = c_bohm_e
   transport_model_input%c_gyrobohm_e = c_gyrobohm_e
   transport_model_input%c_bohm_n = c_bohm_n
+  transport_model_input%c_bohm_n_rho_slope = c_bohm_n_rho_slope
   transport_model_input%prandtl = prandtl
   transport_model_input%pinch_model = pinch_model
   transport_model_input%c_pinch = c_pinch

--- a/src/InOut/read_input.f90
+++ b/src/InOut/read_input.f90
@@ -117,6 +117,8 @@ SUBROUTINE READ_input()
   ALLOCATE(n_quant_ind(1000))
   param_est = -1
   n_quant_ind = -1
+  compute_from_flux = .TRUE.
+  divide_by_2pi = .FALSE.
 
   ! Reading the file
   uinput = 100

--- a/src/LinearAlgebra/interpolation.f90
+++ b/src/LinearAlgebra/interpolation.f90
@@ -315,21 +315,23 @@ CONTAINS
    ! derivatives at (x,y).
    !
    ! d2val_dx2 and d2val_dy2 are formed from second derivatives of the
-   ! Hermite basis. Mixed derivative d2/dxdy is not returned here because
-   ! current callers only need pure second derivatives.
+   ! Hermite basis.  The optional mixed derivative is useful when the
+   ! interpolant is used to refine magnetic critical points.
    !-----------------------------------------------------------------------
-   SUBROUTINE eval_bicubic_with_2nd_derivatives(ny, yvec, nx, xvec, f, fx, fy, fxy, y, x, val, dval_dy, dval_dx, d2val_dy2, d2val_dx2)
+   SUBROUTINE eval_bicubic_with_2nd_derivatives(ny, yvec, nx, xvec, f, fx, fy, fxy, y, x, val, dval_dy, dval_dx, d2val_dy2, d2val_dx2, d2val_dxdy)
       INTEGER, INTENT(IN) :: ny, nx
       REAL*8, INTENT(IN) :: yvec(ny), xvec(nx)
       REAL*8, INTENT(IN) :: f(ny, nx), fx(ny, nx), fy(ny, nx), fxy(ny, nx)
       REAL*8, INTENT(IN) :: y, x
       REAL*8, INTENT(OUT) :: val, dval_dy, dval_dx, d2val_dy2, d2val_dx2
+      REAL*8, INTENT(OUT), OPTIONAL :: d2val_dxdy
       INTEGER :: iy, ix
       REAL*8 :: ty, tx, dy, dx
       REAL*8 :: h00x, h10x, h01x, h11x, h00y, h10y, h01y, h11y
       REAL*8 :: dh00x, dh10x, dh01x, dh11x, dh00y, dh10y, dh01y, dh11y
       REAL*8 :: d2h00x, d2h10x, d2h01x, d2h11x, d2h00y, d2h10y, d2h01y, d2h11y
       REAL*8 :: a0, a1, b0, b1
+      REAL*8 :: da0_dx, da1_dx, db0_dx, db1_dx
 
       CALL find_cell_and_local_coordinate(ny, yvec, y, iy, ty)
       CALL find_cell_and_local_coordinate(nx, xvec, x, ix, tx)
@@ -374,10 +376,12 @@ CONTAINS
 
       val = h00y*a0 + h10y*b0 + h01y*a1 + h11y*b1
 
-      dval_dx = h00y*(dh00x*f(iy,ix)/dx + dh10x*fx(iy,ix) + dh01x*f(iy,ix+1)/dx + dh11x*fx(iy,ix+1)) + &
-                     h10y*(dh00x*dy*fy(iy,ix)/dx + dh10x*dy*fxy(iy,ix) + dh01x*dy*fy(iy,ix+1)/dx + dh11x*dy*fxy(iy,ix+1)) + &
-                     h01y*(dh00x*f(iy+1,ix)/dx + dh10x*fx(iy+1,ix) + dh01x*f(iy+1,ix+1)/dx + dh11x*fx(iy+1,ix+1)) + &
-                     h11y*(dh00x*dy*fy(iy+1,ix)/dx + dh10x*dy*fxy(iy+1,ix) + dh01x*dy*fy(iy+1,ix+1)/dx + dh11x*dy*fxy(iy+1,ix+1))
+      da0_dx = dh00x*f(iy,ix)/dx + dh10x*fx(iy,ix) + dh01x*f(iy,ix+1)/dx + dh11x*fx(iy,ix+1)
+      da1_dx = dh00x*f(iy+1,ix)/dx + dh10x*fx(iy+1,ix) + dh01x*f(iy+1,ix+1)/dx + dh11x*fx(iy+1,ix+1)
+      db0_dx = dh00x*dy*fy(iy,ix)/dx + dh10x*dy*fxy(iy,ix) + dh01x*dy*fy(iy,ix+1)/dx + dh11x*dy*fxy(iy,ix+1)
+      db1_dx = dh00x*dy*fy(iy+1,ix)/dx + dh10x*dy*fxy(iy+1,ix) + dh01x*dy*fy(iy+1,ix+1)/dx + dh11x*dy*fxy(iy+1,ix+1)
+
+      dval_dx = h00y*da0_dx + h10y*db0_dx + h01y*da1_dx + h11y*db1_dx
 
       dval_dy = dh00y*a0/dy + dh10y*b0/dy + dh01y*a1/dy + dh11y*b1/dy
 
@@ -387,6 +391,10 @@ CONTAINS
                         h11y*(d2h00x*dy*fy(iy+1,ix)/dx**2 + d2h10x*dy*fxy(iy+1,ix)/dx + d2h01x*dy*fy(iy+1,ix+1)/dx**2 + d2h11x*dy*fxy(iy+1,ix+1)/dx)
 
       d2val_dy2 = d2h00y*a0/dy**2 + d2h10y*b0/dy**2 + d2h01y*a1/dy**2 + d2h11y*b1/dy**2
+
+      IF (PRESENT(d2val_dxdy)) THEN
+         d2val_dxdy = (dh00y*da0_dx + dh10y*db0_dx + dh01y*da1_dx + dh11y*db1_dx)/dy
+      ENDIF
    END SUBROUTINE eval_bicubic_with_2nd_derivatives
 
   FUNCTION nodesearch(x, y, xy_len, x_array, y_array)
@@ -564,4 +572,3 @@ CONTAINS
   !end function lineintegration
 
 END MODULE interpolation
- 

--- a/src/MHDG.f90
+++ b/src/MHDG.f90
@@ -476,7 +476,7 @@ PROGRAM MHDG
            IF(switch%ME) THEN
               ! ReLoad magnetic field and Jtor
               CALL load_magnetic_field()
-              CALL loadJtorMap()
+              CALL set_toroidal_current()
               CALL SetParticleSource()
               time%dt = time%dt_ME/simpar%refval_time
            ENDIF

--- a/src/MPI_OMP/Communications.f90
+++ b/src/MPI_OMP/Communications.f90
@@ -1140,6 +1140,38 @@ CONTAINS
 
   ENDSUBROUTINE gather_magnetic_field
 
+  SUBROUTINE gather_magnetic_geometry(Mesh_in, rho_glob, normal_glob, region_glob)
+    USE magnetic_geometry_state, ONLY: magnetic_geometry_cache
+    TYPE(Mesh_type), INTENT(IN) :: Mesh_in
+    REAL*8, POINTER, INTENT(OUT) :: rho_glob(:), normal_glob(:, :)
+    INTEGER, POINTER, INTENT(OUT) :: region_glob(:)
+    INTEGER :: i, ierr
+
+    ALLOCATE(rho_glob(Mesh_in%Nno_glob))
+    ALLOCATE(normal_glob(Mesh_in%Nno_glob, 2))
+    ALLOCATE(region_glob(Mesh_in%Nno_glob))
+    rho_glob = -HUGE(0.d0)
+    normal_glob = -HUGE(0.d0)
+    region_glob = -HUGE(0)
+
+    DO i = 1, SIZE(Mesh_in%T, 1)
+       IF (Mesh_in%ghostElems(i) == 1) CYCLE
+       rho_glob(Mesh_in%loc2glob_nodes(Mesh_in%T(i, :))) = &
+            magnetic_geometry_cache%nodal_rho(Mesh_in%T(i, :))
+       normal_glob(Mesh_in%loc2glob_nodes(Mesh_in%T(i, :)), :) = &
+            magnetic_geometry_cache%nodal_normal(Mesh_in%T(i, :), :)
+       region_glob(Mesh_in%loc2glob_nodes(Mesh_in%T(i, :))) = &
+            magnetic_geometry_cache%nodal_region(Mesh_in%T(i, :))
+    ENDDO
+
+    CALL MPI_Allreduce(MPI_IN_PLACE, rho_glob, SIZE(rho_glob), MPI_REAL8, &
+         MPI_MAX, MPI_COMM_WORLD, ierr)
+    CALL MPI_Allreduce(MPI_IN_PLACE, normal_glob, SIZE(normal_glob), MPI_REAL8, &
+         MPI_MAX, MPI_COMM_WORLD, ierr)
+    CALL MPI_Allreduce(MPI_IN_PLACE, region_glob, SIZE(region_glob), MPI_INTEGER, &
+         MPI_MAX, MPI_COMM_WORLD, ierr)
+  END SUBROUTINE gather_magnetic_geometry
+
   SUBROUTINE gather_additional(Mesh_in, scdiff_nodes_glob)
 
     TYPE(Mesh_type)                         :: Mesh_in

--- a/src/Models/NGammaTiTe/transport_1d/README.md
+++ b/src/Models/NGammaTiTe/transport_1d/README.md
@@ -7,6 +7,7 @@ The user-facing settings for this module are read from
 `test/transport_model.nml`. That namelist controls:
 
 - the reference radii used by the Bohm / gyro-Bohm model,
+- the topology regions in which reduced transport is applied,
 - the diffusion replacement window,
 - the pinch model and pinch windows,
 - the coefficient floors.
@@ -62,7 +63,7 @@ The 1D model is refreshed once per NR iteration before Jacobian assembly.
 
 High-level sequence:
 
-1. `fs_transport%build_profiles()`
+1. `fs_transport%build_profiles(region_policy)`
 2. `transport_model_1d%update_from_flux_surfaces(fs_transport)`
 3. HDG uses:
    - `transport_model_1d%apply_1D_diffusion(...)`
@@ -75,6 +76,32 @@ Inside `update_from_flux_surfaces(...)`:
 3. build projected gradients and `delta_te`,
 4. compute Bohm / gyro-Bohm transport,
 5. compute pinch.
+
+## Radial coordinate and topology policy
+
+When magnetic equilibrium geometry is available, reduction and HDG assembly
+read `rho_pol_norm`, the increasing-flux normal, and the topology region at the
+exact volume or face quadrature point from `magnetic_geometry_cache`.  They do
+not interpolate nodal `rho` and do not take a square root of interpolated nodal
+psi.  The legacy nodal-psi path remains only as a compatibility fallback when
+no equilibrium cache exists.
+
+`transport_region_policy` is independent of the radial coordinate:
+
+- `legacy_all_regions` applies reduced transport everywhere and is the
+  compatibility default;
+- `core_and_main_sol` includes the axis-connected core and main SOL but leaves
+  private flux and undefined regions on parameter-file diffusion with zero 1D
+  pinch;
+- `core_only` applies reduced transport only in the axis-connected core.
+
+The policy therefore distinguishes equal-rho points in disconnected topology
+regions.  The main-SOL profile is not clipped at the LCFS and may extend through
+`rho_pol_norm > 1`.
+
+The pinch vector uses the cached increasing-flux normal, so its orientation is
+independent of magnetic-field sign.  Its radial scale is `rho_pol_norm/a_minor`;
+collisionality uses `a_minor*rho_pol_norm/Rmaj`.
 
 ## Persistent vs Derived State
 
@@ -186,14 +213,16 @@ The pinch models are:
 $$
 V_{\mathrm{pinch}}
 = \min\!\left(1,\exp\!\left[1-\frac{\nu_*}{\max(\nu_{\mathrm{th}},\varepsilon)}\right]\right)
-\; c_{\mathrm{pinch}}\, d_{\mathrm{fs}}\, \frac{r}{\max(a,\varepsilon)^2}
+\; c_{\mathrm{pinch}}\, d_{\mathrm{fs}}\,
+\frac{\rho_{\mathrm{pol,n}}}{\max(a_{\mathrm{minor}},\varepsilon)}
 $$
 
 2. Geometric / Polevoi-style baseline
 
 $$
 V_{\mathrm{pinch}}
-= c_{\mathrm{pinch}}\, d_{\mathrm{fs}}\, \frac{r}{\max(a,\varepsilon)^2}
+= c_{\mathrm{pinch}}\, d_{\mathrm{fs}}\,
+\frac{\rho_{\mathrm{pol,n}}}{\max(a_{\mathrm{minor}},\varepsilon)}
 $$
 
 3. Constant pinch

--- a/src/Models/NGammaTiTe/transport_1d/README.md
+++ b/src/Models/NGammaTiTe/transport_1d/README.md
@@ -193,10 +193,19 @@ The particle and momentum transport are then built as
 $$
 d_{\mathrm{fs}}
 = c_{\mathrm{B},n}\,
+\max\!\left(1-c_{\mathrm{B},n,\rho}\rho_{\mathrm{pol,n}},0\right)\,
 \frac{\chi_i\chi_e}{\max(\chi_i+\chi_e,\varepsilon)},
 \qquad
 \nu_{\mathrm{mom}} = \mathrm{Pr}\,\chi_i.
 $$
+
+The default is `c_bohm_n_rho_slope = 0.7`.  The taper coordinate is the
+topology-correct normalized poloidal radius stored in `rho_grid`, rather than
+the historical geometric `r/a`.  It therefore remains consistent in shaped
+and diverted equilibria and is intentionally evaluated for selected main-SOL
+profiles with `rho_pol_norm > 1`.  The lower bound prevents negative particle
+diffusion; setting the slope to zero recovers the topology-corrected untapered
+formula exactly.
 
 Important normalization note:
 

--- a/src/Models/NGammaTiTe/transport_1d/flux_surface_transport_data.f90
+++ b/src/Models/NGammaTiTe/transport_1d/flux_surface_transport_data.f90
@@ -3,6 +3,9 @@ MODULE flux_surface_transport_data
   USE MPI_OMP
   USE HDF5_io_module
   USE interpolation, ONLY: find_cell_and_local_coordinate
+  USE magnetic_geometry_state, ONLY: magnetic_geometry_cache
+  USE transport_models_1d_config, ONLY: tm1d_region_is_included, &
+       transport_region_legacy_all_regions
   IMPLICIT NONE
 
   PRIVATE
@@ -27,14 +30,11 @@ MODULE flux_surface_transport_data
      REAL*8, ALLOCATABLE :: q_sum(:)
      REAL*8, ALLOCATABLE :: omega_sum(:)
      REAL*8, ALLOCATABLE :: Rmaj_sum(:)
-     REAL*8, ALLOCATABLE :: rmin_sum(:)
      REAL*8, ALLOCATABLE :: U_fs(:, :)
      REAL*8, ALLOCATABLE :: Q_rad_fs(:, :)
      REAL*8, ALLOCATABLE :: q_fs(:)
      REAL*8, ALLOCATABLE :: omega_fs(:)
      REAL*8, ALLOCATABLE :: Rmaj_fs(:)
-     REAL*8, ALLOCATABLE :: rmin_fs(:)
-     REAL*8, ALLOCATABLE :: eps_fs(:)
    CONTAINS
      PROCEDURE :: init => fs_init
      PROCEDURE :: destroy => fs_destroy
@@ -75,14 +75,11 @@ CONTAINS
     ALLOCATE(this%q_sum(this%nrho))
     ALLOCATE(this%omega_sum(this%nrho))
     ALLOCATE(this%Rmaj_sum(this%nrho))
-    ALLOCATE(this%rmin_sum(this%nrho))
     ALLOCATE(this%U_fs(this%neq, this%nrho))
     ALLOCATE(this%Q_rad_fs(this%neq, this%nrho))
     ALLOCATE(this%q_fs(this%nrho))
     ALLOCATE(this%omega_fs(this%nrho))
     ALLOCATE(this%Rmaj_fs(this%nrho))
-    ALLOCATE(this%rmin_fs(this%nrho))
-    ALLOCATE(this%eps_fs(this%nrho))
 
     DO i = 1, this%nrho
        this%rho_grid(i) = (i - 1)*this%drho
@@ -102,14 +99,11 @@ CONTAINS
     IF (ALLOCATED(this%q_sum)) DEALLOCATE(this%q_sum)
     IF (ALLOCATED(this%omega_sum)) DEALLOCATE(this%omega_sum)
     IF (ALLOCATED(this%Rmaj_sum)) DEALLOCATE(this%Rmaj_sum)
-    IF (ALLOCATED(this%rmin_sum)) DEALLOCATE(this%rmin_sum)
     IF (ALLOCATED(this%U_fs)) DEALLOCATE(this%U_fs)
     IF (ALLOCATED(this%Q_rad_fs)) DEALLOCATE(this%Q_rad_fs)
     IF (ALLOCATED(this%q_fs)) DEALLOCATE(this%q_fs)
     IF (ALLOCATED(this%omega_fs)) DEALLOCATE(this%omega_fs)
     IF (ALLOCATED(this%Rmaj_fs)) DEALLOCATE(this%Rmaj_fs)
-    IF (ALLOCATED(this%rmin_fs)) DEALLOCATE(this%rmin_fs)
-    IF (ALLOCATED(this%eps_fs)) DEALLOCATE(this%eps_fs)
 
     this%is_initialized = .FALSE.
     this%profiles_built = .FALSE.
@@ -136,26 +130,29 @@ CONTAINS
     this%q_sum = 0.d0
     this%omega_sum = 0.d0
     this%Rmaj_sum = 0.d0
-    this%rmin_sum = 0.d0
     this%U_fs = 0.d0
     this%Q_rad_fs = 0.d0
     this%q_fs = 0.d0
     this%omega_fs = 0.d0
     this%Rmaj_fs = 0.d0
-    this%rmin_fs = 0.d0
-    this%eps_fs = 0.d0
     this%profiles_built = .FALSE.
   END SUBROUTINE fs_reset_accumulators
 
-  SUBROUTINE fs_build_profiles(this)
+  SUBROUTINE fs_build_profiles(this, region_policy)
     CLASS(flux_surface_transport_t), INTENT(INOUT) :: this
+    INTEGER, INTENT(IN) :: region_policy
     REAL*8, ALLOCATABLE :: ures(:, :), qres(:, :)
     REAL*8 :: rho_max_glob
 
     CALL fs_reshape_solution_fields(ures, qres)
-    rho_max_glob = fs_compute_rho_max()
+    IF (region_policy /= transport_region_legacy_all_regions .AND. &
+         .NOT. magnetic_geometry_cache%is_initialized) THEN
+       ERROR STOP 'A topology-aware transport region policy requires the magnetic geometry cache'
+    ENDIF
+
+    rho_max_glob = fs_compute_rho_max(region_policy)
     CALL fs_ensure_grid(this, rho_max_glob)
-    CALL fs_accumulate_profiles(this, ures, qres)
+    CALL fs_accumulate_profiles(this, ures, qres, region_policy)
     CALL this%reduce_profile_sums()
     CALL this%finalize_profiles()
 
@@ -173,7 +170,6 @@ CONTAINS
     CALL MPI_ALLREDUCE(MPI_IN_PLACE, this%q_sum, this%nrho, MPI_REAL8, MPI_SUM, MPI_COMM_WORLD, ierr)
     CALL MPI_ALLREDUCE(MPI_IN_PLACE, this%omega_sum, this%nrho, MPI_REAL8, MPI_SUM, MPI_COMM_WORLD, ierr)
     CALL MPI_ALLREDUCE(MPI_IN_PLACE, this%Rmaj_sum, this%nrho, MPI_REAL8, MPI_SUM, MPI_COMM_WORLD, ierr)
-    CALL MPI_ALLREDUCE(MPI_IN_PLACE, this%rmin_sum, this%nrho, MPI_REAL8, MPI_SUM, MPI_COMM_WORLD, ierr)
 #endif
   END SUBROUTINE fs_reduce_profile_sums
 
@@ -188,8 +184,6 @@ CONTAINS
     this%q_fs = 0.d0
     this%omega_fs = 0.d0
     this%Rmaj_fs = 0.d0
-    this%rmin_fs = 0.d0
-    this%eps_fs = 0.d0
     DO irho = 1, this%nrho
        IF (this%shell_weight(irho) > shell_weight_tol) THEN
           this%U_fs(:, irho) = this%U_sum(:, irho)/this%shell_weight(irho)
@@ -197,8 +191,6 @@ CONTAINS
           this%q_fs(irho) = this%q_sum(irho)/this%shell_weight(irho)
           this%omega_fs(irho) = this%omega_sum(irho)/this%shell_weight(irho)
           this%Rmaj_fs(irho) = this%Rmaj_sum(irho)/this%shell_weight(irho)
-          this%rmin_fs(irho) = this%rmin_sum(irho)/this%shell_weight(irho)
-          this%eps_fs(irho) = this%rmin_fs(irho)/MAX(this%Rmaj_fs(irho), shell_weight_tol)
        END IF
     END DO
     this%profiles_built = .TRUE.
@@ -309,10 +301,11 @@ CONTAINS
     qres = TRANSPOSE(RESHAPE(sol%q, [phys%Neq*Mesh%Ndim, sizeu/phys%Neq]))
   END SUBROUTINE fs_reshape_solution_fields
 
-  FUNCTION fs_compute_rho_max() RESULT(rho_max_glob)
+  FUNCTION fs_compute_rho_max(region_policy) RESULT(rho_max_glob)
+    INTEGER, INTENT(IN) :: region_policy
     REAL*8 :: rho_max_glob
     REAL*8 :: rho_max_local
-    INTEGER :: iel
+    INTEGER :: iel, g
 #ifdef PARALL
     INTEGER :: ierr
 #endif
@@ -320,7 +313,17 @@ CONTAINS
     rho_max_local = 0.d0
     DO iel = 1, Mesh%Nelems
        IF (.NOT. fs_is_local_element(iel)) CYCLE
-       rho_max_local = MAX(rho_max_local, SQRT(MAX(0.d0, MAXVAL(phys%magnetic_psi(Mesh%T(iel, :))))))
+       IF (magnetic_geometry_cache%is_initialized) THEN
+          DO g = 1, refElPol%NGauss2D
+             IF (.NOT. tm1d_region_is_included(region_policy, &
+                  magnetic_geometry_cache%volume_region(g, iel))) CYCLE
+             rho_max_local = MAX(rho_max_local, &
+                  magnetic_geometry_cache%volume_rho(g, iel))
+          ENDDO
+       ELSE
+          rho_max_local = MAX(rho_max_local, &
+               SQRT(MAX(0.d0, MAXVAL(phys%magnetic_psi(Mesh%T(iel, :))))))
+       ENDIF
     END DO
 
     rho_max_glob = rho_max_local
@@ -340,21 +343,23 @@ CONTAINS
     END IF
   END SUBROUTINE fs_ensure_grid
 
-  SUBROUTINE fs_accumulate_profiles(this, ures, qres)
+  SUBROUTINE fs_accumulate_profiles(this, ures, qres, region_policy)
     CLASS(flux_surface_transport_t), INTENT(INOUT) :: this
     REAL*8, INTENT(IN) :: ures(:, :), qres(:, :)
+    INTEGER, INTENT(IN) :: region_policy
     INTEGER :: iel
 
     DO iel = 1, Mesh%Nelems
        IF (.NOT. fs_is_local_element(iel)) CYCLE
-       CALL fs_accumulate_element(this, iel, ures, qres)
+       CALL fs_accumulate_element(this, iel, ures, qres, region_policy)
     END DO
   END SUBROUTINE fs_accumulate_profiles
 
-  SUBROUTINE fs_accumulate_element(this, iel, ures, qres)
+  SUBROUTINE fs_accumulate_element(this, iel, ures, qres, region_policy)
     CLASS(flux_surface_transport_t), INTENT(INOUT) :: this
     INTEGER, INTENT(IN) :: iel
     REAL*8, INTENT(IN) :: ures(:, :), qres(:, :)
+    INTEGER, INTENT(IN) :: region_policy
     INTEGER :: g, ieq, irho
     REAL*8 :: rho_g, weight_g, dpsi_dxi, dpsi_deta, gradpsi_norm
     REAL*8 :: Xel(refElPol%Nnodes2D, 2)
@@ -394,7 +399,24 @@ CONTAINS
     iJ22 = J11/detJ
 
     DO g = 1, refElPol%NGauss2D
-       rho_g = SQRT(MAX(0.d0, psig(g)))
+       IF (magnetic_geometry_cache%is_initialized) THEN
+          IF (.NOT. tm1d_region_is_included(region_policy, &
+               magnetic_geometry_cache%volume_region(g, iel))) CYCLE
+          rho_g = magnetic_geometry_cache%volume_rho(g, iel)
+          npsi = magnetic_geometry_cache%volume_normal(g, iel, :)
+       ELSE
+          rho_g = SQRT(MAX(0.d0, psig(g)))
+          dpsi_dxi = DOT_PRODUCT(refElPol%Nxi2D(g, :), psiel)
+          dpsi_deta = DOT_PRODUCT(refElPol%Neta2D(g, :), psiel)
+          gradpsi(1) = iJ11(g)*dpsi_dxi + iJ12(g)*dpsi_deta
+          gradpsi(2) = iJ21(g)*dpsi_dxi + iJ22(g)*dpsi_deta
+          gradpsi_norm = SQRT(DOT_PRODUCT(gradpsi, gradpsi))
+          IF (gradpsi_norm > gradpsi_tol) THEN
+             npsi = gradpsi/gradpsi_norm
+          ELSE
+             npsi = 0.d0
+          ENDIF
+       ENDIF
        irho = FLOOR(rho_g/this%drho) + 1
        irho = MIN(MAX(irho, 1), this%nrho)
        weight_g = refElPol%gauss_weights2D(g)*ABS(detJ(g))
@@ -405,20 +427,6 @@ CONTAINS
        this%q_sum(irho) = this%q_sum(irho) + q_cylg(g)*weight_g
        this%omega_sum(irho) = this%omega_sum(irho) + omegag(g)*weight_g
        this%Rmaj_sum(irho) = this%Rmaj_sum(irho) + xy(g, 1)*weight_g
-       this%rmin_sum(irho) = this%rmin_sum(irho) + SQRT((xy(g, 1) - phys%r_axis)**2 + (xy(g, 2) - phys%z_axis)**2)*weight_g
-
-       dpsi_dxi = DOT_PRODUCT(refElPol%Nxi2D(g, :), psiel)
-       dpsi_deta = DOT_PRODUCT(refElPol%Neta2D(g, :), psiel)
-       gradpsi(1) = iJ11(g)*dpsi_dxi + iJ12(g)*dpsi_deta
-       gradpsi(2) = iJ21(g)*dpsi_dxi + iJ22(g)*dpsi_deta
-       gradpsi_norm = SQRT(DOT_PRODUCT(gradpsi, gradpsi))
-
-       IF (gradpsi_norm > gradpsi_tol) THEN
-          npsi = gradpsi/gradpsi_norm
-       ELSE
-          npsi = 0.d0
-       END IF
-
        DO ieq = 1, this%neq
           gradu(1) = qeg(g, (ieq - 1)*Mesh%Ndim + 1)
           gradu(2) = qeg(g, (ieq - 1)*Mesh%Ndim + 2)

--- a/src/Models/NGammaTiTe/transport_1d/transport_models_1d.f90
+++ b/src/Models/NGammaTiTe/transport_1d/transport_models_1d.f90
@@ -7,7 +7,8 @@ MODULE transport_models_1d
   USE physics, ONLY: cons2phys
   USE transport_models_1d_config, ONLY: transport_model_config_t, &
        tm1d_config_reset, tm1d_config_apply, tm1d_region_policy_name, &
-       tm1d_region_is_included, tm1d_build_pinch_velocity
+       tm1d_region_is_included, tm1d_build_pinch_velocity, &
+       tm1d_particle_taper_factor
   USE transport_models_1d_derived, ONLY: transport_model_derived_t
   IMPLICIT NONE
 
@@ -186,12 +187,13 @@ CONTAINS
 
   SUBROUTINE tm1d_set_config(this, rho_edge, rho_core, rho_diffusion_model_max, &
        transport_region_policy, c_bohm_i, c_gyrobohm_i, c_bohm_e, &
-       c_gyrobohm_e, c_bohm_n, prandtl, pinch_model, c_pinch, nu_th, &
+       c_gyrobohm_e, c_bohm_n, c_bohm_n_rho_slope, prandtl, pinch_model, &
+       c_pinch, nu_th, &
        vpinch_const_phys, rho_pinch_axis_width, rho_pinch_model_max, &
        rho_pinch_edge_width, rho_blend_width, diff_n_min_phys, diff_u_min_phys, &
        diff_e_min_phys, diff_ee_min_phys)
     CLASS(transport_model_1d_t), INTENT(INOUT) :: this
-    REAL*8, INTENT(IN), OPTIONAL :: rho_edge, rho_core, rho_diffusion_model_max, c_bohm_i, c_gyrobohm_i, c_bohm_e, c_gyrobohm_e, c_bohm_n, prandtl, c_pinch, nu_th, vpinch_const_phys, rho_pinch_axis_width, rho_pinch_model_max, rho_pinch_edge_width, rho_blend_width, diff_n_min_phys, diff_u_min_phys, diff_e_min_phys, diff_ee_min_phys
+    REAL*8, INTENT(IN), OPTIONAL :: rho_edge, rho_core, rho_diffusion_model_max, c_bohm_i, c_gyrobohm_i, c_bohm_e, c_gyrobohm_e, c_bohm_n, c_bohm_n_rho_slope, prandtl, c_pinch, nu_th, vpinch_const_phys, rho_pinch_axis_width, rho_pinch_model_max, rho_pinch_edge_width, rho_blend_width, diff_n_min_phys, diff_u_min_phys, diff_e_min_phys, diff_ee_min_phys
     INTEGER, INTENT(IN), OPTIONAL :: pinch_model
     CHARACTER(LEN=*), INTENT(IN), OPTIONAL :: transport_region_policy
 
@@ -199,7 +201,8 @@ CONTAINS
          rho_edge=rho_edge, rho_core=rho_core, rho_diffusion_model_max=rho_diffusion_model_max, &
          transport_region_policy=transport_region_policy, &
          c_bohm_i=c_bohm_i, c_gyrobohm_i=c_gyrobohm_i, c_bohm_e=c_bohm_e, &
-         c_gyrobohm_e=c_gyrobohm_e, c_bohm_n=c_bohm_n, prandtl=prandtl, &
+         c_gyrobohm_e=c_gyrobohm_e, c_bohm_n=c_bohm_n, &
+         c_bohm_n_rho_slope=c_bohm_n_rho_slope, prandtl=prandtl, &
          pinch_model=pinch_model, c_pinch=c_pinch, nu_th=nu_th, &
          vpinch_const_phys=vpinch_const_phys, rho_pinch_axis_width=rho_pinch_axis_width, &
          rho_pinch_model_max=rho_pinch_model_max, rho_pinch_edge_width=rho_pinch_edge_width, &

--- a/src/Models/NGammaTiTe/transport_1d/transport_models_1d.f90
+++ b/src/Models/NGammaTiTe/transport_1d/transport_models_1d.f90
@@ -5,7 +5,9 @@ MODULE transport_models_1d
   USE flux_surface_transport_data, ONLY: flux_surface_transport_t
   USE interpolation, ONLY: find_cell_and_local_coordinate
   USE physics, ONLY: cons2phys
-  USE transport_models_1d_config, ONLY: transport_model_config_t, tm1d_config_reset, tm1d_config_apply
+  USE transport_models_1d_config, ONLY: transport_model_config_t, &
+       tm1d_config_reset, tm1d_config_apply, tm1d_region_policy_name, &
+       tm1d_region_is_included, tm1d_build_pinch_velocity
   USE transport_models_1d_derived, ONLY: transport_model_derived_t
   IMPLICIT NONE
 
@@ -81,10 +83,13 @@ MODULE transport_models_1d
        CLASS(transport_model_1d_t), INTENT(INOUT) :: this
        TYPE(transport_model_derived_t), INTENT(IN) :: work
      END SUBROUTINE tm1d_compute_constant_pinch
-     MODULE SUBROUTINE tm1d_compute_1D_pinch_matrix(this, b, rho, APinch)
+     MODULE SUBROUTINE tm1d_compute_1D_pinch_matrix(this, b, rho, APinch, &
+          region, outward_normal)
        CLASS(transport_model_1d_t), INTENT(IN) :: this
        REAL*8, INTENT(IN) :: b(:), rho
        REAL*8, INTENT(OUT) :: APinch(:,:)
+       INTEGER, INTENT(IN) :: region
+       REAL*8, INTENT(IN) :: outward_normal(:)
      END SUBROUTINE tm1d_compute_1D_pinch_matrix
      MODULE REAL*8 FUNCTION tm1d_pinch_window(this, rho)
        CLASS(transport_model_1d_t), INTENT(IN) :: this
@@ -118,10 +123,12 @@ MODULE transport_models_1d
        REAL*8, INTENT(IN) :: rho
        REAL*8, INTENT(OUT) :: chi_i, chi_e, d, nu_mom, vpinch
      END SUBROUTINE tm1d_interp_transport
-     MODULE SUBROUTINE tm1d_apply_1D_diffusion(this, rho_pol_norm, diff_iso, diff_ani)
+     MODULE SUBROUTINE tm1d_apply_1D_diffusion(this, rho_pol_norm, diff_iso, &
+          diff_ani, region)
        CLASS(transport_model_1d_t), INTENT(IN) :: this
        REAL*8, INTENT(IN) :: rho_pol_norm(:)
        REAL*8, INTENT(INOUT) :: diff_iso(:, :, :), diff_ani(:, :, :)
+       INTEGER, INTENT(IN) :: region(:)
      END SUBROUTINE tm1d_apply_1D_diffusion
   END INTERFACE
 
@@ -177,13 +184,20 @@ CONTAINS
     this%nrho = 0
   END SUBROUTINE tm1d_clear_storage
 
-  SUBROUTINE tm1d_set_config(this, rho_edge, rho_core, rho_diffusion_model_max, c_bohm_i, c_gyrobohm_i, c_bohm_e, c_gyrobohm_e, c_bohm_n, prandtl, pinch_model, c_pinch, nu_th, vpinch_const_phys, rho_pinch_axis_width, rho_pinch_model_max, rho_pinch_edge_width, rho_blend_width, diff_n_min_phys, diff_u_min_phys, diff_e_min_phys, diff_ee_min_phys)
+  SUBROUTINE tm1d_set_config(this, rho_edge, rho_core, rho_diffusion_model_max, &
+       transport_region_policy, c_bohm_i, c_gyrobohm_i, c_bohm_e, &
+       c_gyrobohm_e, c_bohm_n, prandtl, pinch_model, c_pinch, nu_th, &
+       vpinch_const_phys, rho_pinch_axis_width, rho_pinch_model_max, &
+       rho_pinch_edge_width, rho_blend_width, diff_n_min_phys, diff_u_min_phys, &
+       diff_e_min_phys, diff_ee_min_phys)
     CLASS(transport_model_1d_t), INTENT(INOUT) :: this
     REAL*8, INTENT(IN), OPTIONAL :: rho_edge, rho_core, rho_diffusion_model_max, c_bohm_i, c_gyrobohm_i, c_bohm_e, c_gyrobohm_e, c_bohm_n, prandtl, c_pinch, nu_th, vpinch_const_phys, rho_pinch_axis_width, rho_pinch_model_max, rho_pinch_edge_width, rho_blend_width, diff_n_min_phys, diff_u_min_phys, diff_e_min_phys, diff_ee_min_phys
     INTEGER, INTENT(IN), OPTIONAL :: pinch_model
+    CHARACTER(LEN=*), INTENT(IN), OPTIONAL :: transport_region_policy
 
     CALL tm1d_config_apply(this%config, simpar%refval_time, simpar%refval_length, &
          rho_edge=rho_edge, rho_core=rho_core, rho_diffusion_model_max=rho_diffusion_model_max, &
+         transport_region_policy=transport_region_policy, &
          c_bohm_i=c_bohm_i, c_gyrobohm_i=c_gyrobohm_i, c_bohm_e=c_bohm_e, &
          c_gyrobohm_e=c_gyrobohm_e, c_bohm_n=c_bohm_n, prandtl=prandtl, &
          pinch_model=pinch_model, c_pinch=c_pinch, nu_th=nu_th, &

--- a/src/Models/NGammaTiTe/transport_1d/transport_models_1d_config.f90
+++ b/src/Models/NGammaTiTe/transport_1d/transport_models_1d_config.f90
@@ -1,16 +1,28 @@
 MODULE transport_models_1d_config
+  USE magnetic_topology, ONLY: magnetic_region_core, magnetic_region_main_sol
   IMPLICIT NONE
 
   PRIVATE
   PUBLIC :: transport_model_config_t, tm1d_config_reset, tm1d_config_apply
+  PUBLIC :: tm1d_region_policy_from_name, tm1d_region_policy_name
+  PUBLIC :: tm1d_region_is_included, tm1d_build_pinch_velocity
+  PUBLIC :: transport_region_legacy_all_regions
+  PUBLIC :: transport_region_core_and_main_sol, transport_region_core_only
 
   REAL*8, PARAMETER :: rho_edge_default = 0.99d0
   REAL*8, PARAMETER :: rho_core_default = 0.8d0
+  INTEGER, PARAMETER :: transport_region_legacy_all_regions = 0
+  INTEGER, PARAMETER :: transport_region_core_and_main_sol = 1
+  INTEGER, PARAMETER :: transport_region_core_only = 2
+  CHARACTER(LEN=32), PARAMETER :: transport_region_policy_names(0:2) = &
+       [CHARACTER(LEN=32) :: 'legacy_all_regions', 'core_and_main_sol', &
+       'core_only']
 
   TYPE :: transport_model_config_t
      REAL*8 :: rho_edge = rho_edge_default
      REAL*8 :: rho_core = rho_core_default
      REAL*8 :: rho_diffusion_model_max = 1.d0
+     INTEGER :: transport_region_policy = transport_region_legacy_all_regions
      INTEGER :: pinch_model = 1
      REAL*8 :: c_pinch = 0.5d0
      REAL*8 :: nu_th = 0.04d0
@@ -39,6 +51,7 @@ CONTAINS
     config%rho_edge = rho_edge_default
     config%rho_core = rho_core_default
     config%rho_diffusion_model_max = 1.d0
+    config%transport_region_policy = transport_region_legacy_all_regions
     config%pinch_model = 1
     config%c_pinch = 0.5d0
     config%nu_th = 0.04d0
@@ -59,15 +72,28 @@ CONTAINS
     config%prandtl = 1.d0
   END SUBROUTINE tm1d_config_reset
 
-  SUBROUTINE tm1d_config_apply(config, refval_time, refval_length, rho_edge, rho_core, rho_diffusion_model_max, c_bohm_i, c_gyrobohm_i, c_bohm_e, c_gyrobohm_e, c_bohm_n, prandtl, pinch_model, c_pinch, nu_th, vpinch_const_phys, rho_pinch_axis_width, rho_pinch_model_max, rho_pinch_edge_width, rho_blend_width, diff_n_min_phys, diff_u_min_phys, diff_e_min_phys, diff_ee_min_phys)
+  SUBROUTINE tm1d_config_apply(config, refval_time, refval_length, rho_edge, &
+       rho_core, rho_diffusion_model_max, transport_region_policy, c_bohm_i, &
+       c_gyrobohm_i, c_bohm_e, c_gyrobohm_e, c_bohm_n, prandtl, pinch_model, &
+       c_pinch, nu_th, vpinch_const_phys, rho_pinch_axis_width, &
+       rho_pinch_model_max, rho_pinch_edge_width, rho_blend_width, &
+       diff_n_min_phys, diff_u_min_phys, diff_e_min_phys, diff_ee_min_phys)
     TYPE(transport_model_config_t), INTENT(INOUT) :: config
     REAL*8, INTENT(IN) :: refval_time, refval_length
     REAL*8, INTENT(IN), OPTIONAL :: rho_edge, rho_core, rho_diffusion_model_max, c_bohm_i, c_gyrobohm_i, c_bohm_e, c_gyrobohm_e, c_bohm_n, prandtl, c_pinch, nu_th, vpinch_const_phys, rho_pinch_axis_width, rho_pinch_model_max, rho_pinch_edge_width, rho_blend_width, diff_n_min_phys, diff_u_min_phys, diff_e_min_phys, diff_ee_min_phys
     INTEGER, INTENT(IN), OPTIONAL :: pinch_model
+    CHARACTER(LEN=*), INTENT(IN), OPTIONAL :: transport_region_policy
+    INTEGER :: policy
+    LOGICAL :: valid
 
     IF (PRESENT(rho_edge)) config%rho_edge = rho_edge
     IF (PRESENT(rho_core)) config%rho_core = rho_core
     IF (PRESENT(rho_diffusion_model_max)) config%rho_diffusion_model_max = rho_diffusion_model_max
+    IF (PRESENT(transport_region_policy)) THEN
+       CALL tm1d_region_policy_from_name(transport_region_policy, policy, valid)
+       IF (.NOT. valid) ERROR STOP 'Invalid transport_region_policy'
+       config%transport_region_policy = policy
+    ENDIF
     IF (PRESENT(c_bohm_i)) config%c_bohm_i = c_bohm_i
     IF (PRESENT(c_gyrobohm_i)) config%c_gyrobohm_i = c_gyrobohm_i
     IF (PRESENT(c_bohm_e)) config%c_bohm_e = c_bohm_e
@@ -87,5 +113,79 @@ CONTAINS
     IF (PRESENT(diff_e_min_phys)) config%diff_e_min = diff_e_min_phys*refval_time/refval_length**2
     IF (PRESENT(diff_ee_min_phys)) config%diff_ee_min = diff_ee_min_phys*refval_time/refval_length**2
   END SUBROUTINE tm1d_config_apply
+
+  SUBROUTINE tm1d_region_policy_from_name(name, policy, valid)
+    CHARACTER(LEN=*), INTENT(IN) :: name
+    INTEGER, INTENT(OUT) :: policy
+    LOGICAL, INTENT(OUT) :: valid
+    CHARACTER(LEN=32) :: normalized
+    INTEGER :: i, code, candidate
+
+    normalized = ADJUSTL(name)
+    DO i = 1, LEN_TRIM(normalized)
+       code = IACHAR(normalized(i:i))
+       IF (code >= IACHAR('A') .AND. code <= IACHAR('Z')) THEN
+          normalized(i:i) = ACHAR(code + IACHAR('a') - IACHAR('A'))
+       ENDIF
+    ENDDO
+
+    policy = transport_region_legacy_all_regions
+    valid = .FALSE.
+    DO candidate = LBOUND(transport_region_policy_names, 1), &
+         UBOUND(transport_region_policy_names, 1)
+       IF (TRIM(normalized) /= TRIM(transport_region_policy_names(candidate))) CYCLE
+       policy = candidate
+       valid = .TRUE.
+       RETURN
+    ENDDO
+  END SUBROUTINE tm1d_region_policy_from_name
+
+  CHARACTER(LEN=32) FUNCTION tm1d_region_policy_name(policy)
+    INTEGER, INTENT(IN) :: policy
+
+    IF (policy < LBOUND(transport_region_policy_names, 1) .OR. &
+         policy > UBOUND(transport_region_policy_names, 1)) THEN
+       tm1d_region_policy_name = 'unknown'
+       RETURN
+    ENDIF
+    tm1d_region_policy_name = transport_region_policy_names(policy)
+  END FUNCTION tm1d_region_policy_name
+
+  LOGICAL FUNCTION tm1d_region_is_included(policy, region)
+    INTEGER, INTENT(IN) :: policy, region
+
+    SELECT CASE (policy)
+    CASE (transport_region_legacy_all_regions)
+       tm1d_region_is_included = .TRUE.
+    CASE (transport_region_core_and_main_sol)
+       tm1d_region_is_included = region == magnetic_region_core .OR. &
+            region == magnetic_region_main_sol
+    CASE (transport_region_core_only)
+       tm1d_region_is_included = region == magnetic_region_core
+    CASE DEFAULT
+       tm1d_region_is_included = .FALSE.
+    END SELECT
+  END FUNCTION tm1d_region_is_included
+
+  SUBROUTINE tm1d_build_pinch_velocity(vpinch, policy, b, outward_normal, velocity)
+    REAL*8, INTENT(IN) :: vpinch, b(:), outward_normal(:)
+    INTEGER, INTENT(IN) :: policy
+    REAL*8, INTENT(OUT) :: velocity(2)
+    REAL*8 :: direction(2), direction_norm
+
+    velocity = 0.d0
+    direction = 0.d0
+    IF (SIZE(outward_normal) >= 2) direction = outward_normal(1:2)
+    direction_norm = NORM2(direction)
+    IF (direction_norm <= 1.d-12) THEN
+       IF (policy /= transport_region_legacy_all_regions) RETURN
+       IF (SIZE(b) < 2) RETURN
+       direction = [b(2), -b(1)]
+       direction_norm = NORM2(direction)
+    ENDIF
+    IF (direction_norm <= 1.d-12) RETURN
+
+    velocity = vpinch*direction/direction_norm
+  END SUBROUTINE tm1d_build_pinch_velocity
 
 END MODULE transport_models_1d_config

--- a/src/Models/NGammaTiTe/transport_1d/transport_models_1d_config.f90
+++ b/src/Models/NGammaTiTe/transport_1d/transport_models_1d_config.f90
@@ -6,6 +6,7 @@ MODULE transport_models_1d_config
   PUBLIC :: transport_model_config_t, tm1d_config_reset, tm1d_config_apply
   PUBLIC :: tm1d_region_policy_from_name, tm1d_region_policy_name
   PUBLIC :: tm1d_region_is_included, tm1d_build_pinch_velocity
+  PUBLIC :: tm1d_particle_taper_factor
   PUBLIC :: transport_region_legacy_all_regions
   PUBLIC :: transport_region_core_and_main_sol, transport_region_core_only
 
@@ -40,6 +41,7 @@ MODULE transport_models_1d_config
      REAL*8 :: c_bohm_e = 8.d-5
      REAL*8 :: c_gyrobohm_e = 3.5d-2
      REAL*8 :: c_bohm_n = 1.d0
+     REAL*8 :: c_bohm_n_rho_slope = 0.7d0
      REAL*8 :: prandtl = 1.d0
   END TYPE transport_model_config_t
 
@@ -69,18 +71,20 @@ CONTAINS
     config%c_bohm_e = 8.d-5
     config%c_gyrobohm_e = 3.5d-2
     config%c_bohm_n = 1.d0
+    config%c_bohm_n_rho_slope = 0.7d0
     config%prandtl = 1.d0
   END SUBROUTINE tm1d_config_reset
 
   SUBROUTINE tm1d_config_apply(config, refval_time, refval_length, rho_edge, &
        rho_core, rho_diffusion_model_max, transport_region_policy, c_bohm_i, &
-       c_gyrobohm_i, c_bohm_e, c_gyrobohm_e, c_bohm_n, prandtl, pinch_model, &
-       c_pinch, nu_th, vpinch_const_phys, rho_pinch_axis_width, &
+       c_gyrobohm_i, c_bohm_e, c_gyrobohm_e, c_bohm_n, &
+       c_bohm_n_rho_slope, prandtl, pinch_model, c_pinch, nu_th, &
+       vpinch_const_phys, rho_pinch_axis_width, &
        rho_pinch_model_max, rho_pinch_edge_width, rho_blend_width, &
        diff_n_min_phys, diff_u_min_phys, diff_e_min_phys, diff_ee_min_phys)
     TYPE(transport_model_config_t), INTENT(INOUT) :: config
     REAL*8, INTENT(IN) :: refval_time, refval_length
-    REAL*8, INTENT(IN), OPTIONAL :: rho_edge, rho_core, rho_diffusion_model_max, c_bohm_i, c_gyrobohm_i, c_bohm_e, c_gyrobohm_e, c_bohm_n, prandtl, c_pinch, nu_th, vpinch_const_phys, rho_pinch_axis_width, rho_pinch_model_max, rho_pinch_edge_width, rho_blend_width, diff_n_min_phys, diff_u_min_phys, diff_e_min_phys, diff_ee_min_phys
+    REAL*8, INTENT(IN), OPTIONAL :: rho_edge, rho_core, rho_diffusion_model_max, c_bohm_i, c_gyrobohm_i, c_bohm_e, c_gyrobohm_e, c_bohm_n, c_bohm_n_rho_slope, prandtl, c_pinch, nu_th, vpinch_const_phys, rho_pinch_axis_width, rho_pinch_model_max, rho_pinch_edge_width, rho_blend_width, diff_n_min_phys, diff_u_min_phys, diff_e_min_phys, diff_ee_min_phys
     INTEGER, INTENT(IN), OPTIONAL :: pinch_model
     CHARACTER(LEN=*), INTENT(IN), OPTIONAL :: transport_region_policy
     INTEGER :: policy
@@ -99,6 +103,8 @@ CONTAINS
     IF (PRESENT(c_bohm_e)) config%c_bohm_e = c_bohm_e
     IF (PRESENT(c_gyrobohm_e)) config%c_gyrobohm_e = c_gyrobohm_e
     IF (PRESENT(c_bohm_n)) config%c_bohm_n = c_bohm_n
+    IF (PRESENT(c_bohm_n_rho_slope)) &
+         config%c_bohm_n_rho_slope = c_bohm_n_rho_slope
     IF (PRESENT(prandtl)) config%prandtl = prandtl
     IF (PRESENT(pinch_model)) config%pinch_model = pinch_model
     IF (PRESENT(c_pinch)) config%c_pinch = c_pinch
@@ -187,5 +193,11 @@ CONTAINS
 
     velocity = vpinch*direction/direction_norm
   END SUBROUTINE tm1d_build_pinch_velocity
+
+  PURE ELEMENTAL REAL*8 FUNCTION tm1d_particle_taper_factor(rho_pol_norm, slope)
+    REAL*8, INTENT(IN) :: rho_pol_norm, slope
+
+    tm1d_particle_taper_factor = MAX(1.d0 - slope*rho_pol_norm, 0.d0)
+  END FUNCTION tm1d_particle_taper_factor
 
 END MODULE transport_models_1d_config

--- a/src/Models/NGammaTiTe/transport_1d/transport_models_1d_derived.f90
+++ b/src/Models/NGammaTiTe/transport_1d/transport_models_1d_derived.f90
@@ -14,7 +14,6 @@ MODULE transport_models_1d_derived
      REAL*8, ALLOCATABLE :: q_fs(:)
      REAL*8, ALLOCATABLE :: omega_fs(:)
      REAL*8, ALLOCATABLE :: Rmaj_fs(:)
-     REAL*8, ALLOCATABLE :: rmin_fs(:)
      REAL*8, ALLOCATABLE :: eps_fs(:)
      REAL*8, ALLOCATABLE :: nuestar_fs(:)
      REAL*8, ALLOCATABLE :: dpe_dr_fs(:)
@@ -46,7 +45,6 @@ CONTAINS
     ALLOCATE(this%q_fs(nrho))
     ALLOCATE(this%omega_fs(nrho))
     ALLOCATE(this%Rmaj_fs(nrho))
-    ALLOCATE(this%rmin_fs(nrho))
     ALLOCATE(this%eps_fs(nrho))
     ALLOCATE(this%nuestar_fs(nrho))
     ALLOCATE(this%dpe_dr_fs(nrho))
@@ -61,7 +59,6 @@ CONTAINS
     this%q_fs = 0.d0
     this%omega_fs = 0.d0
     this%Rmaj_fs = 0.d0
-    this%rmin_fs = 0.d0
     this%eps_fs = 0.d0
     this%nuestar_fs = 0.d0
     this%dpe_dr_fs = 0.d0
@@ -83,7 +80,6 @@ CONTAINS
     IF (ALLOCATED(this%q_fs)) DEALLOCATE(this%q_fs)
     IF (ALLOCATED(this%omega_fs)) DEALLOCATE(this%omega_fs)
     IF (ALLOCATED(this%Rmaj_fs)) DEALLOCATE(this%Rmaj_fs)
-    IF (ALLOCATED(this%rmin_fs)) DEALLOCATE(this%rmin_fs)
     IF (ALLOCATED(this%eps_fs)) DEALLOCATE(this%eps_fs)
     IF (ALLOCATED(this%nuestar_fs)) DEALLOCATE(this%nuestar_fs)
     IF (ALLOCATED(this%dpe_dr_fs)) DEALLOCATE(this%dpe_dr_fs)

--- a/src/Models/NGammaTiTe/transport_1d/transport_models_1d_diffusion_bohm_gyrobohm.f90
+++ b/src/Models/NGammaTiTe/transport_1d/transport_models_1d_diffusion_bohm_gyrobohm.f90
@@ -49,13 +49,18 @@ CONTAINS
   MODULE SUBROUTINE tm1d_compute_mixed_transport(this, work)
     CLASS(transport_model_1d_t), INTENT(INOUT) :: this
     TYPE(transport_model_derived_t), INTENT(INOUT) :: work
+    REAL*8 :: particle_factor(this%nrho)
 
     IF (.NOT. this%is_initialized) RETURN
     IF (this%nrho <= 0) RETURN
 
     this%chi_i_fs = MAX(this%config%c_bohm_i*work%chi_bohm_fs + this%config%c_gyrobohm_i*work%chi_gyrobohm_fs, 1.d-10)
     this%chi_e_fs = MAX(this%config%c_bohm_e*work%chi_bohm_fs + this%config%c_gyrobohm_e*work%chi_gyrobohm_fs, 1.d-10)
-    this%d_fs = this%config%c_bohm_n * this%chi_i_fs*this%chi_e_fs / MAX(this%chi_i_fs + this%chi_e_fs, 1.d-10)
+    particle_factor = this%config%c_bohm_n * &
+         tm1d_particle_taper_factor(this%rho_grid, &
+         this%config%c_bohm_n_rho_slope)
+    this%d_fs = particle_factor * this%chi_i_fs*this%chi_e_fs / &
+         MAX(this%chi_i_fs + this%chi_e_fs, 1.d-10)
     this%nu_mom_fs = this%config%prandtl * this%chi_i_fs
   END SUBROUTINE tm1d_compute_mixed_transport
 

--- a/src/Models/NGammaTiTe/transport_1d/transport_models_1d_io.f90
+++ b/src/Models/NGammaTiTe/transport_1d/transport_models_1d_io.f90
@@ -25,6 +25,11 @@ CONTAINS
     CALL HDF5_real_saving(params_group_id, this%config%rho_core, 'rho_core')
     CALL HDF5_real_saving(params_group_id, this%config%rho_edge, 'rho_edge')
     CALL HDF5_real_saving(params_group_id, this%config%rho_diffusion_model_max, 'rho_diffusion_model_max')
+    CALL HDF5_string_saving(params_group_id, &
+         TRIM(tm1d_region_policy_name(this%config%transport_region_policy)), &
+         'transport_region_policy')
+    CALL HDF5_integer_saving(params_group_id, this%config%transport_region_policy, &
+         'transport_region_policy_id')
     CALL HDF5_real_saving(params_group_id, this%config%rho_blend_width, 'rho_blend_width')
     CALL HDF5_real_saving(params_group_id, this%config%diff_n_min, 'diff_n_min')
     CALL HDF5_real_saving(params_group_id, this%config%diff_u_min, 'diff_u_min')

--- a/src/Models/NGammaTiTe/transport_1d/transport_models_1d_io.f90
+++ b/src/Models/NGammaTiTe/transport_1d/transport_models_1d_io.f90
@@ -40,6 +40,8 @@ CONTAINS
     CALL HDF5_real_saving(params_group_id, this%config%c_bohm_e, 'c_bohm_e')
     CALL HDF5_real_saving(params_group_id, this%config%c_gyrobohm_e, 'c_gyrobohm_e')
     CALL HDF5_real_saving(params_group_id, this%config%c_bohm_n, 'c_bohm_n')
+    CALL HDF5_real_saving(params_group_id, this%config%c_bohm_n_rho_slope, &
+         'c_bohm_n_rho_slope')
     CALL HDF5_real_saving(params_group_id, this%config%prandtl, 'prandtl')
     CALL HDF5_integer_saving(params_group_id, this%config%pinch_model, 'pinch_model')
     CALL HDF5_real_saving(params_group_id, this%config%c_pinch, 'c_pinch')

--- a/src/Models/NGammaTiTe/transport_1d/transport_models_1d_pinch.f90
+++ b/src/Models/NGammaTiTe/transport_1d/transport_models_1d_pinch.f90
@@ -28,9 +28,10 @@ CONTAINS
     REAL*8 :: pinch_factor_militello_fs(this%nrho)
 
     pinch_factor_militello_fs = MIN(1.d0, EXP(1.d0 - work%nuestar_fs/MAX(this%config%nu_th, model_tol)))
-    this%vpinch_fs = pinch_factor_militello_fs * this%config%c_pinch * this%d_fs * work%rmin_fs / MAX(work%a_minor, model_tol)**2
+    this%vpinch_fs = pinch_factor_militello_fs * this%config%c_pinch * &
+         this%d_fs * this%rho_grid / MAX(work%a_minor, model_tol)
 
-    WHERE (work%rmin_fs <= model_tol)
+    WHERE (this%rho_grid <= model_tol)
        this%vpinch_fs = 0.d0
     END WHERE
   END SUBROUTINE tm1d_compute_militello_pinch
@@ -39,9 +40,10 @@ CONTAINS
     CLASS(transport_model_1d_t), INTENT(INOUT) :: this
     TYPE(transport_model_derived_t), INTENT(IN) :: work
 
-    this%vpinch_fs = this%config%c_pinch * this%d_fs * work%rmin_fs / MAX(work%a_minor, model_tol)**2
+    this%vpinch_fs = this%config%c_pinch * this%d_fs * this%rho_grid / &
+         MAX(work%a_minor, model_tol)
 
-    WHERE (work%rmin_fs <= model_tol)
+    WHERE (this%rho_grid <= model_tol)
        this%vpinch_fs = 0.d0
     END WHERE
   END SUBROUTINE tm1d_compute_geometric_pinch
@@ -52,7 +54,7 @@ CONTAINS
 
     this%vpinch_fs = this%config%vpinch_const
 
-    WHERE (work%rmin_fs <= model_tol)
+    WHERE (this%rho_grid <= model_tol)
        this%vpinch_fs = 0.d0
     END WHERE
   END SUBROUTINE tm1d_compute_constant_pinch

--- a/src/Models/NGammaTiTe/transport_1d/transport_models_1d_runtime.f90
+++ b/src/Models/NGammaTiTe/transport_1d/transport_models_1d_runtime.f90
@@ -25,18 +25,23 @@ CONTAINS
     CALL tm1d_interp_profile(this, rho, this%vpinch_fs, vpinch)
   END SUBROUTINE tm1d_interp_transport
 
-  MODULE SUBROUTINE tm1d_apply_1D_diffusion(this, rho_pol_norm, diff_iso, diff_ani)
+  MODULE SUBROUTINE tm1d_apply_1D_diffusion(this, rho_pol_norm, diff_iso, &
+       diff_ani, region)
     CLASS(transport_model_1d_t), INTENT(IN) :: this
     REAL*8, INTENT(IN) :: rho_pol_norm(:)
     REAL*8, INTENT(INOUT) :: diff_iso(:, :, :), diff_ani(:, :, :)
+    INTEGER, INTENT(IN) :: region(:)
     INTEGER :: g
     REAL*8 :: rho_g, w, chi_i, chi_e, d, nu_mom, vpinch
 
     IF (.NOT. this%is_initialized) RETURN
     IF (SIZE(diff_iso, 3) /= SIZE(rho_pol_norm)) RETURN
     IF (SIZE(diff_ani, 3) /= SIZE(rho_pol_norm)) RETURN
+    IF (SIZE(region) /= SIZE(rho_pol_norm)) RETURN
 
     DO g = 1, SIZE(rho_pol_norm)
+       IF (.NOT. tm1d_region_is_included(&
+            this%config%transport_region_policy, region(g))) CYCLE
        rho_g = MAX(rho_pol_norm(g), 0.d0)
        w = tm1d_blend_weight(this, rho_g)
        IF (w <= 0.d0) CYCLE
@@ -60,15 +65,20 @@ CONTAINS
     END DO
   END SUBROUTINE tm1d_apply_1D_diffusion
 
-  MODULE SUBROUTINE tm1d_compute_1D_pinch_matrix(this, b, rho, APinch)
+  MODULE SUBROUTINE tm1d_compute_1D_pinch_matrix(this, b, rho, APinch, &
+       region, outward_normal)
     CLASS(transport_model_1d_t), INTENT(IN) :: this
     REAL*8, INTENT(IN) :: b(:), rho
     REAL*8, INTENT(OUT) :: APinch(:,:)
-    REAL*8 :: vpinch, bnorm(2), bnorm_norm, pinch_weight
+    INTEGER, INTENT(IN) :: region
+    REAL*8, INTENT(IN) :: outward_normal(:)
+    REAL*8 :: vpinch, velocity(2), pinch_weight
     REAL*8 :: chi_i, chi_e, d, nu_mom
 
     APinch = 0.d0
     IF (.NOT. this%is_initialized) RETURN
+    IF (.NOT. tm1d_region_is_included(&
+         this%config%transport_region_policy, region)) RETURN
 
     pinch_weight = tm1d_pinch_window(this, rho)
     IF (pinch_weight <= model_tol) RETURN
@@ -77,13 +87,9 @@ CONTAINS
     vpinch = pinch_weight*vpinch
     IF (ABS(vpinch) <= model_tol) RETURN
 
-    bnorm = b(1:2)
-    bnorm_norm = NORM2(bnorm)
-    IF (bnorm_norm <= model_tol) RETURN
-    bnorm = bnorm/bnorm_norm
-
-    APinch(1,1) = vpinch*bnorm(2)
-    APinch(1,2) = -vpinch*bnorm(1)
+    CALL tm1d_build_pinch_velocity(vpinch, &
+         this%config%transport_region_policy, b, outward_normal, velocity)
+    APinch(1,1:2) = velocity
   END SUBROUTINE tm1d_compute_1D_pinch_matrix
 
 END SUBMODULE transport_models_1d_runtime

--- a/src/Models/NGammaTiTe/transport_1d/transport_models_1d_update.f90
+++ b/src/Models/NGammaTiTe/transport_1d/transport_models_1d_update.f90
@@ -66,8 +66,8 @@ CONTAINS
     work%q_fs = fs_data%q_fs
     work%omega_fs = fs_data%omega_fs
     work%Rmaj_fs = fs_data%Rmaj_fs
-    work%rmin_fs = fs_data%rmin_fs
-    work%eps_fs = fs_data%eps_fs
+    work%eps_fs = work%a_minor*fs_data%rho_grid / &
+         MAX(ABS(work%Rmaj_fs), model_tol)
 
     DEALLOCATE(ua, up)
   END SUBROUTINE tm1d_fill_derived_from_fs

--- a/src/Models/magnetic_field.f90
+++ b/src/Models/magnetic_field.f90
@@ -14,6 +14,15 @@ MODULE magnetic_field
   USE HDF5_io_module
   USE HDF5
   USE interpolation
+  USE magnetic_topology, ONLY: topology_limited, topology_lower_single_null
+  USE magnetic_geometry_state, ONLY: magnetic_equilibrium, &
+       magnetic_geometry_cache, poloidal_field_fit, &
+       fit_poloidal_field_scale, reset_magnetic_geometry_state, &
+       compare_restart_geometry
+  IMPLICIT NONE
+
+  REAL*8, PARAMETER :: field_fit_accepted_rms = 0.10d0
+  REAL*8, PARAMETER :: field_fit_fatal_rms = 0.25d0
 CONTAINS
 
   !**********************************************
@@ -52,6 +61,7 @@ CONTAINS
   !**********************************************
   SUBROUTINE load_magnetic_field
 
+    CALL reset_magnetic_geometry_state()
     phys%B = 0.
     phys%magnetic_flux = 0.
     phys%magnetic_psi = 0.
@@ -71,6 +81,9 @@ CONTAINS
        IF (input%field_from_grid) THEN
           CALL load_magnetic_field_grid
        ELSE
+          IF (MPIvar%glob_id == 0) THEN
+             WRITE (6, *) 'WARNING: node-based equilibrium input has no PR03 topology cache; using stored magnetic data.'
+          ENDIF
           CALL load_magnetic_field_nodes
        ENDIF
 
@@ -222,17 +235,19 @@ CONTAINS
     INTEGER(HID_T)                    :: file_id
     REAL*8, POINTER, DIMENSION(:, :)  :: r2D, z2D, flux2D, Br2D, Bz2D, Bphi2D
     REAL*8, ALLOCATABLE, DIMENSION(:) :: xvec, yvec
-   REAL*8, ALLOCATABLE, DIMENSION(:, :) :: flux_dx2D, flux_dy2D, flux_dxy2D
-   REAL*8, ALLOCATABLE, DIMENSION(:, :) :: Bphi_dx2D, Bphi_dy2D, Bphi_dxy2D
+    REAL*8, ALLOCATABLE, DIMENSION(:, :) :: Bphi_dx2D, Bphi_dy2D, Bphi_dxy2D
+    REAL*8, ALLOCATABLE :: wall_coordinates(:, :)
+    INTEGER, ALLOCATABLE :: wall_faces(:, :)
     REAL*8                            :: x, y
-   REAL*8                            :: x_safe, dflux_dx, dflux_dy
+    REAL*8                            :: x_safe, dflux_dx, dflux_dy
     REAL*8                            :: Br, Bz, Bt, flux, psiSep, dt_ME,t_ME
     CHARACTER(LEN=1000) :: fname
     CHARACTER(50)  :: nit
-    INTEGER                           :: axis_ind_tmp(2)
+    CHARACTER(LEN=256) :: geometry_message, restart_message
 
-   REAL*8                            :: q_cyl, omega,a,flux_axis,flux_span
-   REAL*8                            :: sign_psi, fac_2pi_field
+    REAL*8                            :: q_cyl, omega,a
+    REAL*8                            :: alpha, fac_2pi_field
+    LOGICAL                           :: restart_mismatch
 
 
 
@@ -316,46 +331,67 @@ CONTAINS
     xvec = r2D(1, :)
     yvec = z2D(:, 1)
 
-   ! Refine axis to mesh domain (find minimum flux only within mesh bounds)
-   CALL find_axis_in_mesh_domain(ip, jp, flux2D, yvec, xvec, axis_ind_tmp, phys%r_axis, phys%z_axis)
+    CALL magnetic_equilibrium%init(xvec, yvec, flux2D, ierr, geometry_message)
+    IF (ierr /= 0) THEN
+       IF (MPIvar%glob_id == 0) WRITE (6, *) 'Magnetic topology initialization failed: ', TRIM(geometry_message)
+       STOP
+    ENDIF
+    CALL collect_physical_wall(wall_coordinates, wall_faces)
+    CALL magnetic_equilibrium%analyze(psiSep, wall_coordinates, wall_faces, &
+         refElPol%coord1d, ierr, geometry_message)
+    IF (ierr /= 0) THEN
+       IF (MPIvar%glob_id == 0) WRITE (6, *) 'Magnetic topology analysis failed: ', TRIM(geometry_message)
+       STOP
+    ENDIF
+    DEALLOCATE(wall_coordinates, wall_faces)
 
-   ALLOCATE (Bphi_dx2D(ip, jp))
-   ALLOCATE (Bphi_dy2D(ip, jp))
-   ALLOCATE (Bphi_dxy2D(ip, jp))
-   CALL build_bicubic_derivatives(ip, yvec, jp, xvec, Bphi2D, Bphi_dx2D, Bphi_dy2D, Bphi_dxy2D)
+    phys%r_axis = magnetic_equilibrium%r_axis
+    phys%z_axis = magnetic_equilibrium%z_axis
+    phys%a_minor = magnetic_equilibrium%a_minor
+    phys%Flux2Dmin = magnetic_equilibrium%psi_axis
+    CALL compare_restart_geometry(phys%lscale, restart_mismatch, restart_message)
+    IF (restart_mismatch .AND. MPIvar%glob_id == 0) THEN
+       WRITE (6, *) 'WARNING: ', TRIM(restart_message)
+    ENDIF
 
-    IF (input%compute_from_flux) THEN
-       ALLOCATE (flux_dx2D(ip, jp))
-       ALLOCATE (flux_dy2D(ip, jp))
-       ALLOCATE (flux_dxy2D(ip, jp))
-       CALL build_bicubic_derivatives(ip, yvec, jp, xvec, flux2D, flux_dx2D, flux_dy2D, flux_dxy2D)
+    ALLOCATE (Bphi_dx2D(ip, jp))
+    ALLOCATE (Bphi_dy2D(ip, jp))
+    ALLOCATE (Bphi_dxy2D(ip, jp))
+    CALL build_bicubic_derivatives(ip, yvec, jp, xvec, Bphi2D, &
+         Bphi_dx2D, Bphi_dy2D, Bphi_dxy2D)
 
+    CALL fit_poloidal_field_scale(magnetic_equilibrium, xvec, yvec, Br2D, &
+         Bz2D, simpar%refval_length, poloidal_field_fit)
+    IF (poloidal_field_fit%is_valid) THEN
+       alpha = poloidal_field_fit%alpha
+    ELSE
        fac_2pi_field = 1.d0
        IF (input%divide_by_2pi) fac_2pi_field = 2.d0*PI
+       alpha = determine_flux_sign(ip, jp, xvec, yvec, Br2D, Bz2D)/fac_2pi_field
+    ENDIF
+    CALL report_field_fit(alpha)
 
-       sign_psi = determine_flux_sign(ip, jp, r2D, Br2D, Bz2D, flux_dx2D, flux_dy2D, fac_2pi_field)
-    ELSE
-       sign_psi = 1.d0
+    CALL magnetic_geometry_cache%build(magnetic_equilibrium, Mesh%X(:, 1:2), &
+         Mesh%T, refElPol%N2D, refElPol%face_nodes, refElPol%N1D)
+    IF (.NOT. magnetic_geometry_cache%is_initialized) THEN
+       IF (MPIvar%glob_id == 0) WRITE (6, *) 'Magnetic topology cache initialization failed.'
+       STOP
     ENDIF
 
     DO i = 1, Mesh%Nnodes
        x = Mesh%X(i, 1)
        y = Mesh%X(i, 2)
+       CALL magnetic_equilibrium%evaluate_flux(x, y, flux, dflux_dx, dflux_dy)
        IF (input%compute_from_flux) THEN
-          CALL eval_bicubic_with_derivatives(ip, yvec, jp, xvec, flux2D, flux_dx2D, flux_dy2D, flux_dxy2D, y, x, flux, dflux_dy, dflux_dx)
           x_safe = MAX(ABS(x), 1.d-12)
-          Br = -sign_psi*dflux_dy/x_safe/simpar%refval_length**2
-          Bz = sign_psi*dflux_dx/x_safe/simpar%refval_length**2
-          IF (input%divide_by_2pi) THEN
-             Br = Br/2.d0/PI
-             Bz = Bz/2.d0/PI
-          ENDIF
+          Br = -alpha*dflux_dy/x_safe/simpar%refval_length**2
+          Bz =  alpha*dflux_dx/x_safe/simpar%refval_length**2
        ELSE
           Br = interpolate(ip, yvec, jp, xvec, Br2D, y, x, 1e-12)
           Bz = interpolate(ip, yvec, jp, xvec, Bz2D, y, x, 1e-12)
-          flux = interpolate(ip, yvec, jp, xvec, flux2D, y, x, 1e-12)
        ENDIF
-      CALL eval_bicubic_value(ip, yvec, jp, xvec, Bphi2D, Bphi_dx2D, Bphi_dy2D, Bphi_dxy2D, y, x, Bt)
+       CALL eval_bicubic_value(ip, yvec, jp, xvec, Bphi2D, Bphi_dx2D, &
+            Bphi_dy2D, Bphi_dxy2D, y, x, Bt)
 
        omega = simpar%refval_charge/simpar%refval_mass*SQRT(Br**2+Bz**2+Bt**2)*simpar%refval_time
        a = SQRT((x-phys%r_axis)**2+(y-phys%z_axis)**2)
@@ -373,6 +409,7 @@ CONTAINS
           phys%B(ind, 2) = Bz
           phys%B(ind, 3) = Bt
           phys%magnetic_flux(ind) = flux
+          phys%magnetic_psi(ind) = magnetic_geometry_cache%nodal_psi_normalized(i)
 
           phys%omega(ind) = omega
           phys%q_cyl(ind) = q_cyl
@@ -381,33 +418,13 @@ CONTAINS
        END DO
 #endif
     END DO
-    IF (input%compute_from_flux) THEN
-       DEALLOCATE (flux_dx2D, flux_dy2D, flux_dxy2D)
-    ENDIF
     DEALLOCATE (Bphi_dx2D, Bphi_dy2D, Bphi_dxy2D)
 
-
-   ! Flux at magnetic axis for normalization (avoid using global minimum over full mesh)
-   flux_axis = flux2D(axis_ind_tmp(1), axis_ind_tmp(2))
-   phys%Flux2Dmin = flux_axis
     phys%Flux2Dmax = MAXVAL(phys%magnetic_flux)
 
 #ifdef PARALL
     CALL MPI_ALLREDUCE(MPI_IN_PLACE, phys%Flux2Dmax, 1, MPI_REAL8, MPI_MAX, MPI_COMM_WORLD, ierr)
-    CALL MPI_ALLREDUCE(MPI_IN_PLACE, phys%Flux2Dmin, 1, MPI_REAL8, MPI_MIN, MPI_COMM_WORLD, ierr)
 #endif
-
-    ! Magnetic flux normalized to separatrix: PSI (axis-referenced)
-    flux_span = psiSep - phys%Flux2Dmin
-    IF (ABS(flux_span) > 1.d-14) THEN
-       phys%magnetic_psi = (phys%magnetic_flux - phys%Flux2Dmin)/flux_span
-    ELSE
-       phys%magnetic_psi = 0.d0
-    ENDIF
-
-    ! Find a_minor from mesh nodes on psi~1 contour (robust on actual computation mesh)
-    CALL compute_a_minor_from_mesh_psi(phys%a_minor)
-
 
     IF (switch%ME) THEN
        time%dt_ME = dt_ME
@@ -420,90 +437,19 @@ CONTAINS
 
   END SUBROUTINE load_magnetic_field_grid
 
-  SUBROUTINE compute_a_minor_from_mesh_psi(a_minor)
-    REAL*8, INTENT(OUT) :: a_minor
-    REAL*8 :: r_min, r_max
-    INTEGER :: i
-#ifdef PARALL
-    INTEGER :: ierr
-#endif
-
-    r_min = HUGE(0.d0)
-    r_max = -HUGE(0.d0)
-    DO i = 1, Mesh%Nnodes
-       IF (ABS(phys%magnetic_psi(i) - 1.d0) < 1.d-3) THEN
-          r_min = MIN(r_min, Mesh%X(i, 1))
-          r_max = MAX(r_max, Mesh%X(i, 1))
-       ENDIF
-    ENDDO
-#ifdef PARALL
-    CALL MPI_ALLREDUCE(r_min, r_min, 1, MPI_REAL8, MPI_MIN, MPI_COMM_WORLD, ierr)
-    CALL MPI_ALLREDUCE(r_max, r_max, 1, MPI_REAL8, MPI_MAX, MPI_COMM_WORLD, ierr)
-#endif
-
-    a_minor = 0.d0
-    IF (r_max > r_min) a_minor = 0.5d0*(r_max - r_min)
-  END SUBROUTINE compute_a_minor_from_mesh_psi
-
-   SUBROUTINE find_axis_in_mesh_domain(ny, nx, flux2D, yvec, xvec, axis_ind, r_axis, z_axis)
-    ! Find magnetic axis (minimum flux) within specified mesh domain bounds
-    INTEGER, INTENT(IN) :: ny, nx
-    REAL*8, INTENT(IN) :: flux2D(ny, nx)
-    REAL*8, INTENT(IN) :: yvec(ny), xvec(nx)
-    INTEGER, INTENT(OUT) :: axis_ind(2)
-    REAL*8, INTENT(OUT) :: r_axis, z_axis
-    
-         REAL*8 :: flux_min, r_mesh_min, r_mesh_max, z_mesh_min, z_mesh_max
-#ifdef PARALL
-      INTEGER :: ierr
-#endif
-    INTEGER :: ii, jj
-
-      r_mesh_min = MINVAL(Mesh%X(:,1))
-      r_mesh_max = MAXVAL(Mesh%X(:,1))
-      z_mesh_min = MINVAL(Mesh%X(:,2))
-      z_mesh_max = MAXVAL(Mesh%X(:,2))
-
-#ifdef PARALL
-         CALL MPI_ALLREDUCE(MPI_IN_PLACE, r_mesh_min, 1, MPI_REAL8, MPI_MIN, MPI_COMM_WORLD, ierr)
-         CALL MPI_ALLREDUCE(MPI_IN_PLACE, r_mesh_max, 1, MPI_REAL8, MPI_MAX, MPI_COMM_WORLD, ierr)
-         CALL MPI_ALLREDUCE(MPI_IN_PLACE, z_mesh_min, 1, MPI_REAL8, MPI_MIN, MPI_COMM_WORLD, ierr)
-         CALL MPI_ALLREDUCE(MPI_IN_PLACE, z_mesh_max, 1, MPI_REAL8, MPI_MAX, MPI_COMM_WORLD, ierr)
-#endif
-    
-    flux_min = HUGE(0.d0)
-    axis_ind = (/1, 1/)
-    
-    DO ii = 1, ny
-       DO jj = 1, nx
-          IF (xvec(jj) >= r_mesh_min .AND. xvec(jj) <= r_mesh_max .AND. &
-              yvec(ii) >= z_mesh_min .AND. yvec(ii) <= z_mesh_max) THEN
-             IF (flux2D(ii,jj) < flux_min) THEN
-                flux_min = flux2D(ii,jj)
-                axis_ind = (/ii, jj/)
-             ENDIF
-          ENDIF
-       ENDDO
-    ENDDO
-    
-    r_axis = xvec(axis_ind(2))
-    z_axis = yvec(axis_ind(1))
-  END SUBROUTINE find_axis_in_mesh_domain
-
-   REAL*8 FUNCTION determine_flux_sign(ny, nx, r2D, Br2D, Bz2D, flux_dx2D, flux_dy2D, fac_2pi_field)
+   REAL*8 FUNCTION determine_flux_sign(ny, nx, r, z, Br2D, Bz2D)
       INTEGER, INTENT(IN) :: ny, nx
-      REAL*8, INTENT(IN) :: r2D(ny, nx), Br2D(ny, nx), Bz2D(ny, nx)
-      REAL*8, INTENT(IN) :: flux_dx2D(ny, nx), flux_dy2D(ny, nx)
-      REAL*8, INTENT(IN) :: fac_2pi_field
+      REAL*8, INTENT(IN) :: r(nx), z(ny), Br2D(ny, nx), Bz2D(ny, nx)
       INTEGER :: ii, jj
-      REAL*8 :: score_sign, x_safe, Br_ref, Bz_ref
+      REAL*8 :: score_sign, x_safe, Br_ref, Bz_ref, psi, psi_r, psi_z
 
       score_sign = 0.d0
       DO ii = 1, ny
           DO jj = 1, nx
-               x_safe = MAX(ABS(r2D(ii,jj)), 1.d-12)
-               Br_ref = -flux_dy2D(ii,jj)/x_safe/simpar%refval_length**2/fac_2pi_field
-               Bz_ref = flux_dx2D(ii,jj)/x_safe/simpar%refval_length**2/fac_2pi_field
+               CALL magnetic_equilibrium%evaluate_flux(r(jj), z(ii), psi, psi_r, psi_z)
+               x_safe = MAX(ABS(r(jj)), 1.d-12)
+               Br_ref = -psi_z/x_safe/simpar%refval_length**2
+               Bz_ref = psi_r/x_safe/simpar%refval_length**2
                score_sign = score_sign + Br_ref*Br2D(ii,jj) + Bz_ref*Bz2D(ii,jj)
           ENDDO
       ENDDO
@@ -511,6 +457,105 @@ CONTAINS
       determine_flux_sign = 1.d0
       IF (score_sign < 0.d0) determine_flux_sign = -1.d0
    END FUNCTION determine_flux_sign
+
+   SUBROUTINE collect_physical_wall(wall_coordinates, wall_faces)
+     REAL*8, ALLOCATABLE, INTENT(OUT) :: wall_coordinates(:, :)
+     INTEGER, ALLOCATABLE, INTENT(OUT) :: wall_faces(:, :)
+     INTEGER :: i, index, nwall
+     INTEGER, ALLOCATABLE :: all_faces(:, :), keep_face(:)
+#ifdef PARALL
+     INTEGER :: ierr
+
+     ALLOCATE(wall_coordinates(Mesh%Nno_glob, 2))
+     ALLOCATE(all_faces(Mesh%Nextfaces_glob, Mesh%Nnodesperface))
+     ALLOCATE(keep_face(Mesh%Nextfaces_glob))
+     wall_coordinates = -HUGE(0.d0)
+     all_faces = 0
+     keep_face = 0
+     DO i = 1, Mesh%Nelems
+        IF (Mesh%ghostElems(i) == 0) THEN
+           wall_coordinates(Mesh%loc2glob_nodes(Mesh%T(i, :)), :) = &
+                Mesh%X(Mesh%T(i, :), 1:2)
+        ENDIF
+     ENDDO
+     DO i = 1, Mesh%Nextfaces
+        IF (Mesh%ghostFaces(Mesh%Nintfaces + i) /= 0) CYCLE
+        index = Mesh%loc2glob_fa(Mesh%Nintfaces + i) - Mesh%Nintfaces_glob
+        all_faces(index, :) = Mesh%loc2glob_nodes(Mesh%Tb(i, :))
+        IF (.NOT. ALLOCATED(Mesh%periodic_faces) .OR. &
+             Mesh%periodic_faces(i) == 0) keep_face(index) = 1
+     ENDDO
+     CALL MPI_ALLREDUCE(MPI_IN_PLACE, wall_coordinates, SIZE(wall_coordinates), &
+          MPI_REAL8, MPI_MAX, MPI_COMM_WORLD, ierr)
+     CALL MPI_ALLREDUCE(MPI_IN_PLACE, all_faces, SIZE(all_faces), MPI_INTEGER, &
+          MPI_SUM, MPI_COMM_WORLD, ierr)
+     CALL MPI_ALLREDUCE(MPI_IN_PLACE, keep_face, SIZE(keep_face), MPI_INTEGER, &
+          MPI_MAX, MPI_COMM_WORLD, ierr)
+#else
+     ALLOCATE(wall_coordinates(Mesh%Nnodes, 2))
+     ALLOCATE(all_faces(Mesh%Nextfaces, Mesh%Nnodesperface))
+     ALLOCATE(keep_face(Mesh%Nextfaces))
+     wall_coordinates = Mesh%X(:, 1:2)
+     all_faces = Mesh%Tb
+     keep_face = 1
+     IF (ALLOCATED(Mesh%periodic_faces)) THEN
+        WHERE (Mesh%periodic_faces /= 0) keep_face = 0
+     ENDIF
+#endif
+     nwall = COUNT(keep_face == 1)
+     ALLOCATE(wall_faces(nwall, Mesh%Nnodesperface))
+     index = 0
+     DO i = 1, SIZE(all_faces, 1)
+        IF (keep_face(i) == 0) CYCLE
+        index = index + 1
+        wall_faces(index, :) = all_faces(i, :)
+     ENDDO
+     DEALLOCATE(all_faces, keep_face)
+   END SUBROUTINE collect_physical_wall
+
+   SUBROUTINE report_field_fit(alpha)
+     REAL*8, INTENT(IN) :: alpha
+     CHARACTER(LEN=32) :: topology_name
+     LOGICAL :: fatal_fit
+
+     fatal_fit = poloidal_field_fit%is_valid .AND. input%compute_from_flux .AND. &
+          poloidal_field_fit%relative_rms > field_fit_fatal_rms
+     IF (MPIvar%glob_id == 0) THEN
+        SELECT CASE (magnetic_equilibrium%topology_kind)
+        CASE (topology_limited)
+           topology_name = 'limited'
+        CASE (topology_lower_single_null)
+           topology_name = 'lower_single_null'
+        CASE DEFAULT
+           topology_name = 'unknown'
+        END SELECT
+        WRITE (6, '(A,A)') ' Magnetic topology: ', TRIM(topology_name)
+        WRITE (6, '(A,2ES16.7)') ' Effective/input psiSep: ', &
+             magnetic_equilibrium%psi_lcfs, magnetic_equilibrium%psi_sep_input
+        WRITE (6, '(A,3ES16.7)') ' Axis R/Z and a_minor [solver units]: ', &
+             magnetic_equilibrium%r_axis, magnetic_equilibrium%z_axis, &
+             magnetic_equilibrium%a_minor
+        IF (poloidal_field_fit%is_valid) THEN
+           WRITE (6, '(A,ES16.7,A,F7.3,A,I0)') ' Poloidal-field fit alpha: ', &
+                alpha, ', relative RMS: ', 100.d0*poloidal_field_fit%relative_rms, &
+                ' %, samples: ', poloidal_field_fit%sample_count
+           IF (fatal_fit) THEN
+              WRITE (6, *) 'ERROR: poloidal-field fit residual exceeds 25% for flux-derived operation.'
+           ELSEIF (poloidal_field_fit%relative_rms > field_fit_fatal_rms) THEN
+              WRITE (6, *) 'WARNING: stored Bpol is inconsistent with psi by more than 25%.'
+           ELSEIF (poloidal_field_fit%relative_rms > field_fit_accepted_rms) THEN
+              WRITE (6, *) 'WARNING: poloidal-field fit residual is between 10% and 25%.'
+           ENDIF
+        ELSE
+           WRITE (6, '(A,ES16.7)') &
+                ' WARNING: no valid Bpol/psi fit; using divide_by_2pi fallback alpha ', alpha
+        ENDIF
+        IF (.NOT. input%compute_from_flux) THEN
+           WRITE (6, *) 'WARNING: topology/rho come from bicubic psi, while physics uses stored HDF5 Br/Bz.'
+        ENDIF
+     ENDIF
+     IF (fatal_fit) STOP
+   END SUBROUTINE report_field_fit
 
   !***********************************************************************
   ! Magnetic field loaded by a hdf5 file in the nodes !TODO modify for 3D

--- a/src/Models/magnetic_field.f90
+++ b/src/Models/magnetic_field.f90
@@ -14,15 +14,24 @@ MODULE magnetic_field
   USE HDF5_io_module
   USE HDF5
   USE interpolation
-  USE magnetic_topology, ONLY: topology_limited, topology_lower_single_null
+  USE magnetic_topology, ONLY: topology_limited, topology_lower_single_null, &
+       magnetic_region_core
   USE magnetic_geometry_state, ONLY: magnetic_equilibrium, &
        magnetic_geometry_cache, poloidal_field_fit, &
        fit_poloidal_field_scale, reset_magnetic_geometry_state, &
-       compare_restart_geometry
+       compare_restart_geometry, fit_toroidal_current_sign, &
+       evaluate_flux_derived_toroidal_current, &
+       toroidal_current_from_flux, &
+       toroidal_current_comparison, toroidal_current_comparison_t, &
+       field_alpha_plus_one, field_alpha_minus_one, &
+       field_alpha_plus_inverse_two_pi, field_alpha_minus_inverse_two_pi
   IMPLICIT NONE
 
   REAL*8, PARAMETER :: field_fit_accepted_rms = 0.10d0
   REAL*8, PARAMETER :: field_fit_fatal_rms = 0.25d0
+  REAL*8, PARAMETER :: field_alpha_canonical_warning = 0.10d0
+  REAL*8, PARAMETER :: jtor_comparison_warning = 0.25d0
+  REAL*8, PARAMETER :: stored_jtor_outside_core_warning = 0.01d0
 CONTAINS
 
   !**********************************************
@@ -53,7 +62,7 @@ CONTAINS
 
   SUBROUTINE load_magnetic_field_Jtor
       CALL load_magnetic_field()
-      IF (switch%ohmicsrc) CALL loadJtorMap()
+      IF (switch%ohmicsrc) CALL set_toroidal_current()
   ENDSUBROUTINE load_magnetic_field_Jtor
 
   !**********************************************
@@ -363,12 +372,13 @@ CONTAINS
     CALL fit_poloidal_field_scale(magnetic_equilibrium, xvec, yvec, Br2D, &
          Bz2D, simpar%refval_length, poloidal_field_fit)
     IF (poloidal_field_fit%is_valid) THEN
-       alpha = poloidal_field_fit%alpha
+       alpha = poloidal_field_fit%applied_alpha
     ELSE
        fac_2pi_field = 1.d0
        IF (input%divide_by_2pi) fac_2pi_field = 2.d0*PI
        alpha = determine_flux_sign(ip, jp, xvec, yvec, Br2D, Bz2D)/fac_2pi_field
     ENDIF
+    poloidal_field_fit%applied_alpha = alpha
     CALL report_field_fit(alpha)
 
     CALL magnetic_geometry_cache%build(magnetic_equilibrium, Mesh%X(:, 1:2), &
@@ -515,11 +525,13 @@ CONTAINS
 
    SUBROUTINE report_field_fit(alpha)
      REAL*8, INTENT(IN) :: alpha
-     CHARACTER(LEN=32) :: topology_name
+     CHARACTER(LEN=32) :: topology_name, convention_name
      LOGICAL :: fatal_fit
+     REAL*8 :: inverse_two_pi
 
+     inverse_two_pi = 1.d0/(2.d0*PI)
      fatal_fit = poloidal_field_fit%is_valid .AND. input%compute_from_flux .AND. &
-          poloidal_field_fit%relative_rms > field_fit_fatal_rms
+          poloidal_field_fit%applied_relative_rms > field_fit_fatal_rms
      IF (MPIvar%glob_id == 0) THEN
         SELECT CASE (magnetic_equilibrium%topology_kind)
         CASE (topology_limited)
@@ -532,26 +544,54 @@ CONTAINS
         WRITE (6, '(A,A)') ' Magnetic topology: ', TRIM(topology_name)
         WRITE (6, '(A,2ES16.7)') ' Effective/input psiSep: ', &
              magnetic_equilibrium%psi_lcfs, magnetic_equilibrium%psi_sep_input
-        WRITE (6, '(A,3ES16.7)') ' Axis R/Z and a_minor [solver units]: ', &
-             magnetic_equilibrium%r_axis, magnetic_equilibrium%z_axis, &
-             magnetic_equilibrium%a_minor
+        WRITE (6, '(A,3ES16.7)') ' Axis R/Z and a_minor [m]: ', &
+             magnetic_equilibrium%r_axis*phys%lscale, &
+             magnetic_equilibrium%z_axis*phys%lscale, &
+             magnetic_equilibrium%a_minor*phys%lscale
+        WRITE (6, '(A)') &
+             ' Poloidal-field convention: (Br,Bz) = alpha/R*(-dpsi/dZ,dpsi/dR)'
         IF (poloidal_field_fit%is_valid) THEN
-           WRITE (6, '(A,ES16.7,A,F7.3,A,I0)') ' Poloidal-field fit alpha: ', &
-                alpha, ', relative RMS: ', 100.d0*poloidal_field_fit%relative_rms, &
+           SELECT CASE (poloidal_field_fit%convention_id)
+           CASE (field_alpha_plus_one)
+              convention_name = '+1'
+           CASE (field_alpha_minus_one)
+              convention_name = '-1'
+           CASE (field_alpha_plus_inverse_two_pi)
+              convention_name = '+1/(2*pi)'
+           CASE (field_alpha_minus_inverse_two_pi)
+              convention_name = '-1/(2*pi)'
+           CASE DEFAULT
+              convention_name = 'unknown'
+           END SELECT
+           WRITE (6, '(A,ES16.7,A,A,A,ES16.7)') &
+                ' Poloidal-field unconstrained alpha: ', poloidal_field_fit%alpha, &
+                '; selected ', TRIM(convention_name), ': ', alpha
+           WRITE (6, '(A,F7.3,A,F7.3,A,I0)') &
+                ' Poloidal-field RMS unconstrained/applied: ', &
+                100.d0*poloidal_field_fit%relative_rms, ' / ', &
+                100.d0*poloidal_field_fit%applied_relative_rms, &
                 ' %, samples: ', poloidal_field_fit%sample_count
+           IF (poloidal_field_fit%canonical_relative_difference > &
+                field_alpha_canonical_warning) THEN
+              WRITE (6, '(A,F7.2,A)') &
+                   ' WARNING: fitted alpha differs from the nearest supported convention by ', &
+                   100.d0*poloidal_field_fit%canonical_relative_difference, ' %.'
+           ENDIF
            IF (fatal_fit) THEN
               WRITE (6, *) 'ERROR: poloidal-field fit residual exceeds 25% for flux-derived operation.'
-           ELSEIF (poloidal_field_fit%relative_rms > field_fit_fatal_rms) THEN
+           ELSEIF (poloidal_field_fit%applied_relative_rms > field_fit_fatal_rms) THEN
               WRITE (6, *) 'WARNING: stored Bpol is inconsistent with psi by more than 25%.'
-           ELSEIF (poloidal_field_fit%relative_rms > field_fit_accepted_rms) THEN
+           ELSEIF (poloidal_field_fit%applied_relative_rms > field_fit_accepted_rms) THEN
               WRITE (6, *) 'WARNING: poloidal-field fit residual is between 10% and 25%.'
            ENDIF
         ELSE
-           WRITE (6, '(A,ES16.7)') &
-                ' WARNING: no valid Bpol/psi fit; using divide_by_2pi fallback alpha ', alpha
+           WRITE (6, '(A,ES16.7,A,ES16.7)') &
+                ' WARNING: no valid Bpol/psi fit; fallback alpha: ', alpha, &
+                ', 1/(2*pi): ', inverse_two_pi
         ENDIF
         IF (.NOT. input%compute_from_flux) THEN
-           WRITE (6, *) 'WARNING: topology/rho come from bicubic psi, while physics uses stored HDF5 Br/Bz.'
+           WRITE (6, *) &
+                'WARNING: topology/rho come from bicubic psi, while physics uses stored HDF5 Br/Bz and Jtor.'
         ENDIF
      ENDIF
      IF (fatal_fit) STOP
@@ -1097,13 +1137,79 @@ CONTAINS
   END SUBROUTINE calcRippleField
 #endif
 
-  ! Below are routines from Manuel MHDG v2.1. Copy as it without any check: TODO adapt it to global magnetic field
+  SUBROUTINE set_toroidal_current()
+    REAL*8, ALLOCATABLE :: stored_toroidal_current(:)
 
-  SUBROUTINE loadJtorMap()
+    toroidal_current_from_flux = .FALSE.
+    toroidal_current_comparison = toroidal_current_comparison_t()
 
+    IF (utils%printint > 0 .AND. MPIvar%glob_id == 0) THEN
+       WRITE (6, *) '*************************************************'
+       WRITE (6, *) '*          SETTING TOROIDAL CURRENT             *'
+       WRITE (6, *) '*************************************************'
+    ENDIF
 
+    IF (input%compute_from_flux .AND. magnetic_equilibrium%is_initialized) THEN
+       CALL derive_toroidal_current_from_flux()
+       toroidal_current_from_flux = .TRUE.
+       ALLOCATE(stored_toroidal_current(SIZE(phys%Jtor)))
+       CALL load_stored_toroidal_current(stored_toroidal_current)
+       CALL fit_and_apply_toroidal_current_sign(stored_toroidal_current)
+       DEALLOCATE(stored_toroidal_current)
+    ELSE
+       IF (input%compute_from_flux .AND. MPIvar%glob_id == 0) THEN
+          WRITE (6, *) &
+               'WARNING: no bicubic psi geometry; falling back to stored HDF5 Jtor.'
+       ENDIF
+       CALL load_stored_toroidal_current(phys%Jtor)
+    ENDIF
 
+    CALL computeIplasma()
+    IF (MPIvar%glob_id == 0) WRITE (6, *) 'I_p =  ', phys%I_p, '[MA]'
+  END SUBROUTINE set_toroidal_current
 
+  SUBROUTINE derive_toroidal_current_from_flux()
+    INTEGER :: i, ind
+#ifdef TOR3D
+    INTEGER :: j
+#endif
+    REAL*8 :: x, y, jtor_value, alpha
+    LOGICAL :: is_valid
+
+    alpha = poloidal_field_fit%applied_alpha
+    IF (ABS(alpha) <= TINY(1.d0)) THEN
+       IF (MPIvar%glob_id == 0) WRITE (6, *) &
+            'ERROR: flux-derived Jtor requires the applied poloidal-field alpha.'
+       STOP
+    ENDIF
+
+    phys%Jtor = 0.d0
+    DO i = 1, Mesh%Nnodes
+       IF (magnetic_geometry_cache%nodal_region(i) /= magnetic_region_core) CYCLE
+       x = Mesh%X(i, 1)
+       y = Mesh%X(i, 2)
+       CALL evaluate_flux_derived_toroidal_current(magnetic_equilibrium, x, y, &
+            simpar%refval_length, alpha, jtor_value, is_valid)
+       IF (.NOT. is_valid) THEN
+          IF (MPIvar%glob_id == 0) WRITE (6, *) &
+               'ERROR: invalid flux-derived Jtor at solver node ', i, x, y
+          STOP
+       ENDIF
+       ind = i
+#ifdef TOR3D
+       DO j = 1, Mesh%Nnodes_toroidal
+          ind = (j - 1)*Mesh%Nnodes + i
+#endif
+          phys%Jtor(ind) = jtor_value
+#ifdef TOR3D
+       ENDDO
+#endif
+    ENDDO
+
+  END SUBROUTINE derive_toroidal_current_from_flux
+
+  SUBROUTINE load_stored_toroidal_current(jtor_at_nodes)
+    REAL*8, INTENT(OUT) :: jtor_at_nodes(:)
     INTEGER        :: i,ierr,ip,jp,ind, k
 #ifdef TOR3D
     INTEGER        :: j
@@ -1113,24 +1219,14 @@ CONTAINS
     CHARACTER(LEN=1000)    :: fname
     CHARACTER(70)        :: nit
 
-   REAL*8,POINTER,DIMENSION(:,:) :: r2D,z2D,Jtor
-   REAL*8,ALLOCATABLE,DIMENSION(:)   :: xvec,yvec
-   REAL*8,ALLOCATABLE,DIMENSION(:,:) :: Jtor_dx2D, Jtor_dy2D, Jtor_dxy2D
+    REAL*8, POINTER, DIMENSION(:,:) :: r2D, z2D, Jtor
+    REAL*8, ALLOCATABLE, DIMENSION(:) :: xvec, yvec
+    REAL*8, ALLOCATABLE, DIMENSION(:,:) :: Jtor_dx2D, Jtor_dy2D, Jtor_dxy2D
     REAL*8                            :: dt_ME,t_ME
     REAL*8                            :: x,y
     REAL*8,PARAMETER                  :: tol = 1.e-12
-
-
-    IF (utils%printint > 0) THEN
-       IF(MPIvar%glob_id .EQ. 0) THEN
-          WRITE (6, *) '*************************************************'
-          WRITE (6, *) '*          LOADING TOROIDAL CURRENT             *'
-          WRITE (6, *) '*************************************************'
-       ENDIF
-    END IF
-
     ! Allocate storing space in phys
-    phys%Jtor = 0.
+    jtor_at_nodes = 0.d0
 
     ! Read file
     IF (switch%testcase>=50 .AND. switch%testcase<60) THEN
@@ -1195,12 +1291,13 @@ CONTAINS
     ALLOCATE(yvec(ip))
     xvec = r2D(1,:)
     yvec = z2D(:,1)
-       ALLOCATE(Jtor_dx2D(ip,jp))
-       ALLOCATE(Jtor_dy2D(ip,jp))
-       ALLOCATE(Jtor_dxy2D(ip,jp))
-       CALL build_bicubic_derivatives(ip, yvec, jp, xvec, Jtor, Jtor_dx2D, Jtor_dy2D, Jtor_dxy2D)
+    ALLOCATE(Jtor_dx2D(ip,jp))
+    ALLOCATE(Jtor_dy2D(ip,jp))
+    ALLOCATE(Jtor_dxy2D(ip,jp))
+    CALL build_bicubic_derivatives(ip, yvec, jp, xvec, Jtor, Jtor_dx2D, &
+         Jtor_dy2D, Jtor_dxy2D)
 
-       DO i = 1,Mesh%Nnodes
+    DO i = 1, Mesh%Nnodes
        x = Mesh%X(i,1)
        y = Mesh%X(i,2)
        ind = i
@@ -1208,18 +1305,12 @@ CONTAINS
        DO j = 1, Mesh%Nnodes_toroidal
           ind = (j - 1)*Mesh%Nnodes + i
 #endif
-         CALL eval_bicubic_value(ip, yvec, jp, xvec, Jtor, Jtor_dx2D, Jtor_dy2D, Jtor_dxy2D, y, x, phys%Jtor(ind))
+          CALL eval_bicubic_value(ip, yvec, jp, xvec, Jtor, Jtor_dx2D, &
+               Jtor_dy2D, Jtor_dxy2D, y, x, jtor_at_nodes(ind))
 #ifdef TOR3D
-       END DO
+       ENDDO
 #endif
-    END DO
-
-    !Compute Ip
-    CALL computeIplasma()
-
-    IF (MPIvar%glob_id .EQ. 0) THEN
-       WRITE(6,*) 'I_p =  ', phys%I_p, '[MA]'
-    ENDIF
+    ENDDO
 
     ! check that time is the same
     IF (switch%ME) THEN
@@ -1230,10 +1321,93 @@ CONTAINS
     ENDIF
 
     ! Free memory
-   DEALLOCATE(r2D,z2D,Jtor,xvec,yvec,Jtor_dx2D,Jtor_dy2D,Jtor_dxy2D)
+    DEALLOCATE(r2D, z2D, Jtor, xvec, yvec, Jtor_dx2D, Jtor_dy2D, &
+         Jtor_dxy2D)
     NULLIFY(r2D,z2D,Jtor)
 
-  END SUBROUTINE loadJtorMap
+  END SUBROUTINE load_stored_toroidal_current
+
+  SUBROUTINE fit_and_apply_toroidal_current_sign(stored_toroidal_current)
+    REAL*8, INTENT(IN) :: stored_toroidal_current(:)
+    REAL*8 :: element_coordinates(refElPol%Nnodes2D, 2)
+    REAL*8 :: derived_nodes(refElPol%Nnodes2D), stored_nodes(refElPol%Nnodes2D)
+    REAL*8 :: derived_gauss(refElPol%NGauss2D), stored_gauss(refElPol%NGauss2D)
+    REAL*8 :: jacobian_11(refElPol%NGauss2D), jacobian_12(refElPol%NGauss2D)
+    REAL*8 :: jacobian_21(refElPol%NGauss2D), jacobian_22(refElPol%NGauss2D)
+    REAL*8 :: det_jacobian(refElPol%NGauss2D), stats(4), weight
+    INTEGER :: sample_counts(2), iel, igauss
+#ifdef PARALL
+    INTEGER :: ierr
+#endif
+
+    IF (.NOT. magnetic_geometry_cache%is_initialized) RETURN
+    stats = 0.d0
+    sample_counts = 0
+    DO iel = 1, Mesh%Nelems
+#ifdef PARALL
+       IF (Mesh%ghostElems(iel) /= 0) CYCLE
+#endif
+       element_coordinates = Mesh%X(Mesh%T(iel, :), 1:2)
+       derived_nodes = phys%Jtor(Mesh%T(iel, :))
+       stored_nodes = stored_toroidal_current(Mesh%T(iel, :))
+       derived_gauss = MATMUL(refElPol%N2D, derived_nodes)
+       stored_gauss = MATMUL(refElPol%N2D, stored_nodes)
+       jacobian_11 = MATMUL(refElPol%Nxi2D, element_coordinates(:, 1))
+       jacobian_12 = MATMUL(refElPol%Nxi2D, element_coordinates(:, 2))
+       jacobian_21 = MATMUL(refElPol%Neta2D, element_coordinates(:, 1))
+       jacobian_22 = MATMUL(refElPol%Neta2D, element_coordinates(:, 2))
+       det_jacobian = jacobian_11*jacobian_22 - jacobian_21*jacobian_12
+
+       DO igauss = 1, refElPol%NGauss2D
+          weight = refElPol%gauss_weights2D(igauss)*ABS(det_jacobian(igauss))
+          IF (magnetic_geometry_cache%volume_region(igauss, iel) == &
+               magnetic_region_core) THEN
+             stats(1) = stats(1) + weight*stored_gauss(igauss)**2
+             stats(2) = stats(2) + weight*derived_gauss(igauss)**2
+             stats(3) = stats(3) + weight*derived_gauss(igauss)* &
+                  stored_gauss(igauss)
+             sample_counts(1) = sample_counts(1) + 1
+          ELSE
+             stats(4) = stats(4) + weight*stored_gauss(igauss)**2
+             sample_counts(2) = sample_counts(2) + 1
+          ENDIF
+       ENDDO
+    ENDDO
+
+#ifdef PARALL
+    CALL MPI_ALLREDUCE(MPI_IN_PLACE, stats, SIZE(stats), MPI_REAL8, MPI_SUM, &
+         MPI_COMM_WORLD, ierr)
+    CALL MPI_ALLREDUCE(MPI_IN_PLACE, sample_counts, SIZE(sample_counts), &
+         MPI_INTEGER, MPI_SUM, MPI_COMM_WORLD, ierr)
+#endif
+    CALL fit_toroidal_current_sign(stats(2), stats(1), stats(3), &
+         toroidal_current_comparison)
+    toroidal_current_comparison%core_sample_count = sample_counts(1)
+    toroidal_current_comparison%outside_sample_count = sample_counts(2)
+    IF (.NOT. toroidal_current_comparison%is_valid) THEN
+       IF (MPIvar%glob_id == 0) WRITE (6, '(A)') &
+            ' WARNING: no valid stored-current fit; using raw Ampere-law Jtor sign.'
+       RETURN
+    ENDIF
+
+    phys%Jtor = REAL(toroidal_current_comparison%applied_sign, 8)*phys%Jtor
+    toroidal_current_comparison%stored_outside_core_relative_l2 = &
+         SQRT(stats(4)/stats(1))
+    IF (MPIvar%glob_id == 0) THEN
+       WRITE (6, '(A,I0,A,F8.3,A)') &
+            ' Jtor convention: ', &
+            toroidal_current_comparison%applied_sign, &
+            '; core RMS vs stored: ', &
+            100.d0*toroidal_current_comparison%core_relative_l2, &
+            ' %'
+       IF (toroidal_current_comparison%core_relative_l2 > &
+            jtor_comparison_warning) WRITE (6, '(A)') &
+            ' WARNING: flux-derived and stored core Jtor differ by more than 25% in relative L2.'
+       IF (toroidal_current_comparison%stored_outside_core_relative_l2 > &
+            stored_jtor_outside_core_warning) WRITE (6, '(A)') &
+            ' WARNING: stored Jtor outside the detected core exceeds 1% of its core L2 norm.'
+    ENDIF
+  END SUBROUTINE fit_and_apply_toroidal_current_sign
 
   SUBROUTINE loadMagneticFieldFromExperimentalData()
 
@@ -1352,6 +1526,11 @@ CONTAINS
 
        ! Toroidal current at Gauss points
        Jtorg = MATMUL(refElPol%N2D,Jtorel)
+       IF (toroidal_current_from_flux .AND. &
+            magnetic_geometry_cache%is_initialized) THEN
+          WHERE (magnetic_geometry_cache%volume_region(:, iel) /= &
+               magnetic_region_core) Jtorg = 0.d0
+       ENDIF
 
        ! Jacobian
        J11 = MATMUL(refElPol%Nxi2D,Xel(:,1))                             ! ng x 1

--- a/src/Models/magnetic_field.f90
+++ b/src/Models/magnetic_field.f90
@@ -352,6 +352,11 @@ CONTAINS
        IF (MPIvar%glob_id == 0) WRITE (6, *) 'Magnetic topology analysis failed: ', TRIM(geometry_message)
        STOP
     ENDIF
+    IF (.NOT. magnetic_equilibrium%lcfs_extrema_refined .AND. &
+         MPIvar%glob_id == 0) THEN
+       WRITE (6, *) &
+            'WARNING: LCFS radial-extremum refinement did not converge; using sampled extrema.'
+    ENDIF
     DEALLOCATE(wall_coordinates, wall_faces)
 
     phys%r_axis = magnetic_equilibrium%r_axis

--- a/src/Models/magnetic_geometry_state.f90
+++ b/src/Models/magnetic_geometry_state.f90
@@ -1,0 +1,258 @@
+MODULE magnetic_geometry_state
+  USE, INTRINSIC :: ieee_arithmetic, ONLY: ieee_is_finite
+  USE magnetic_topology, ONLY: equilibrium_geometry_t
+  IMPLICIT NONE
+
+  PRIVATE
+
+  REAL*8, PARAMETER :: near_null_fraction = 1.d-6
+  REAL*8, PARAMETER :: restart_comparison_tolerance = 1.d-6
+
+  TYPE, PUBLIC :: poloidal_field_fit_t
+     LOGICAL :: is_valid = .FALSE.
+     REAL*8 :: alpha = 0.d0
+     REAL*8 :: relative_rms = HUGE(0.d0)
+     INTEGER :: sample_count = 0
+  END TYPE poloidal_field_fit_t
+
+  TYPE, PUBLIC :: magnetic_geometry_cache_t
+     LOGICAL :: is_initialized = .FALSE.
+     INTEGER :: generation = 0
+     INTEGER :: equilibrium_generation = 0
+     REAL*8, ALLOCATABLE :: nodal_psi_normalized(:)
+     REAL*8, ALLOCATABLE :: nodal_rho(:)
+     REAL*8, ALLOCATABLE :: nodal_normal(:, :)
+     INTEGER, ALLOCATABLE :: nodal_region(:)
+     REAL*8, ALLOCATABLE :: volume_psi_normalized(:, :)
+     REAL*8, ALLOCATABLE :: volume_rho(:, :)
+     REAL*8, ALLOCATABLE :: volume_normal(:, :, :)
+     INTEGER, ALLOCATABLE :: volume_region(:, :)
+     REAL*8, ALLOCATABLE :: face_psi_normalized(:, :, :)
+     REAL*8, ALLOCATABLE :: face_rho(:, :, :)
+     REAL*8, ALLOCATABLE :: face_normal(:, :, :, :)
+     INTEGER, ALLOCATABLE :: face_region(:, :, :)
+   CONTAINS
+     PROCEDURE :: build => magnetic_geometry_cache_build
+     PROCEDURE :: clear => magnetic_geometry_cache_clear
+  END TYPE magnetic_geometry_cache_t
+
+  TYPE(equilibrium_geometry_t), SAVE, PUBLIC :: magnetic_equilibrium
+  TYPE(magnetic_geometry_cache_t), SAVE, PUBLIC :: magnetic_geometry_cache
+  TYPE(poloidal_field_fit_t), SAVE, PUBLIC :: poloidal_field_fit
+
+  LOGICAL, SAVE :: restart_reference_is_present = .FALSE.
+  REAL*8, SAVE :: restart_psi_lcfs = 0.d0
+  REAL*8, SAVE :: restart_r_axis = 0.d0
+  REAL*8, SAVE :: restart_z_axis = 0.d0
+  REAL*8, SAVE :: restart_a_minor = 0.d0
+
+  PUBLIC :: fit_poloidal_field_scale
+  PUBLIC :: reset_magnetic_geometry_state
+  PUBLIC :: set_restart_geometry_reference
+  PUBLIC :: compare_restart_geometry
+
+CONTAINS
+
+  SUBROUTINE reset_magnetic_geometry_state()
+    CALL magnetic_equilibrium%clear()
+    CALL magnetic_geometry_cache%clear()
+    poloidal_field_fit = poloidal_field_fit_t()
+  END SUBROUTINE reset_magnetic_geometry_state
+
+  SUBROUTINE fit_poloidal_field_scale(geometry, r, z, br, bz, length_scale, fit)
+    TYPE(equilibrium_geometry_t), INTENT(IN) :: geometry
+    REAL*8, INTENT(IN) :: r(:), z(:)
+    REAL*8, INTENT(IN) :: br(:, :), bz(:, :)
+    REAL*8, INTENT(IN) :: length_scale
+    TYPE(poloidal_field_fit_t), INTENT(OUT) :: fit
+    INTEGER :: ir, iz
+    REAL*8 :: psi, psi_r, psi_z, gr, gz, gnorm, bnorm
+    REAL*8 :: max_gnorm, max_bnorm, numerator, denominator
+    REAL*8 :: residual, reference_norm, r_safe, length_scale_squared
+
+    fit = poloidal_field_fit_t()
+    IF (.NOT. geometry%is_initialized) RETURN
+    IF (SIZE(br, 1) /= SIZE(z) .OR. SIZE(br, 2) /= SIZE(r)) RETURN
+    IF (ANY(SHAPE(br) /= SHAPE(bz)) .OR. length_scale <= 0.d0) RETURN
+
+    length_scale_squared = length_scale*length_scale
+    max_gnorm = 0.d0
+    max_bnorm = 0.d0
+    DO ir = 1, SIZE(r)
+       DO iz = 1, SIZE(z)
+          CALL geometry%evaluate_flux(r(ir), z(iz), psi, psi_r, psi_z)
+          r_safe = MAX(ABS(r(ir)), 1.d-12)
+          gr = -psi_z/(r_safe*length_scale_squared)
+          gz = psi_r/(r_safe*length_scale_squared)
+          gnorm = HYPOT(gr, gz)
+          bnorm = HYPOT(br(iz, ir), bz(iz, ir))
+          IF (ieee_is_finite(gnorm)) max_gnorm = MAX(max_gnorm, gnorm)
+          IF (ieee_is_finite(bnorm)) max_bnorm = MAX(max_bnorm, bnorm)
+       ENDDO
+    ENDDO
+    IF (max_gnorm <= TINY(1.d0) .OR. max_bnorm <= TINY(1.d0)) RETURN
+
+    numerator = 0.d0
+    denominator = 0.d0
+    reference_norm = 0.d0
+    DO ir = 1, SIZE(r)
+       DO iz = 1, SIZE(z)
+          CALL geometry%evaluate_flux(r(ir), z(iz), psi, psi_r, psi_z)
+          r_safe = MAX(ABS(r(ir)), 1.d-12)
+          gr = -psi_z/(r_safe*length_scale_squared)
+          gz = psi_r/(r_safe*length_scale_squared)
+          gnorm = HYPOT(gr, gz)
+          bnorm = HYPOT(br(iz, ir), bz(iz, ir))
+          IF (.NOT. ieee_is_finite(gnorm) .OR. .NOT. ieee_is_finite(bnorm)) CYCLE
+          IF (gnorm < near_null_fraction*max_gnorm .OR. &
+               bnorm < near_null_fraction*max_bnorm) CYCLE
+          numerator = numerator + gr*br(iz, ir) + gz*bz(iz, ir)
+          denominator = denominator + gr*gr + gz*gz
+          reference_norm = reference_norm + br(iz, ir)**2 + bz(iz, ir)**2
+          fit%sample_count = fit%sample_count + 1
+       ENDDO
+    ENDDO
+    IF (fit%sample_count < 4 .OR. denominator <= TINY(1.d0) .OR. &
+         reference_norm <= TINY(1.d0)) RETURN
+
+    fit%alpha = numerator/denominator
+    residual = MAX(reference_norm - 2.d0*fit%alpha*numerator + &
+         fit%alpha*fit%alpha*denominator, 0.d0)
+    fit%relative_rms = SQRT(residual/reference_norm)
+    fit%is_valid = ieee_is_finite(fit%alpha) .AND. &
+         ieee_is_finite(fit%relative_rms)
+  END SUBROUTINE fit_poloidal_field_scale
+
+  SUBROUTINE magnetic_geometry_cache_build(this, geometry, node_coordinates, &
+       elements, volume_shape, face_nodes, face_shape)
+    CLASS(magnetic_geometry_cache_t), INTENT(INOUT) :: this
+    TYPE(equilibrium_geometry_t), INTENT(IN) :: geometry
+    REAL*8, INTENT(IN) :: node_coordinates(:, :)
+    INTEGER, INTENT(IN) :: elements(:, :), face_nodes(:, :)
+    REAL*8, INTENT(IN) :: volume_shape(:, :), face_shape(:, :)
+    INTEGER :: inode, ielem, iface, igauss
+    REAL*8 :: xy(2)
+    REAL*8, ALLOCATABLE :: element_coordinates(:, :), face_coordinates(:, :)
+
+    CALL this%clear()
+    IF (.NOT. geometry%is_initialized) RETURN
+    IF (SIZE(node_coordinates, 2) < 2) RETURN
+
+    ALLOCATE(this%nodal_psi_normalized(SIZE(node_coordinates, 1)))
+    ALLOCATE(this%nodal_rho(SIZE(node_coordinates, 1)))
+    ALLOCATE(this%nodal_normal(SIZE(node_coordinates, 1), 2))
+    ALLOCATE(this%nodal_region(SIZE(node_coordinates, 1)))
+    DO inode = 1, SIZE(node_coordinates, 1)
+       CALL geometry%evaluate_topology(node_coordinates(inode, 1), &
+            node_coordinates(inode, 2), this%nodal_psi_normalized(inode), &
+            this%nodal_rho(inode), this%nodal_normal(inode, :), &
+            this%nodal_region(inode))
+    ENDDO
+
+    ALLOCATE(this%volume_psi_normalized(SIZE(volume_shape, 1), SIZE(elements, 1)))
+    ALLOCATE(this%volume_rho(SIZE(volume_shape, 1), SIZE(elements, 1)))
+    ALLOCATE(this%volume_normal(SIZE(volume_shape, 1), SIZE(elements, 1), 2))
+    ALLOCATE(this%volume_region(SIZE(volume_shape, 1), SIZE(elements, 1)))
+    ALLOCATE(element_coordinates(SIZE(elements, 2), 2))
+    DO ielem = 1, SIZE(elements, 1)
+       element_coordinates = node_coordinates(elements(ielem, :), 1:2)
+       DO igauss = 1, SIZE(volume_shape, 1)
+          xy = MATMUL(volume_shape(igauss, :), element_coordinates)
+          CALL geometry%evaluate_topology(xy(1), xy(2), &
+               this%volume_psi_normalized(igauss, ielem), &
+               this%volume_rho(igauss, ielem), &
+               this%volume_normal(igauss, ielem, :), &
+               this%volume_region(igauss, ielem))
+       ENDDO
+    ENDDO
+    DEALLOCATE(element_coordinates)
+
+    ALLOCATE(this%face_psi_normalized(SIZE(face_shape, 1), &
+         SIZE(face_nodes, 1), SIZE(elements, 1)))
+    ALLOCATE(this%face_rho(SIZE(face_shape, 1), SIZE(face_nodes, 1), &
+         SIZE(elements, 1)))
+    ALLOCATE(this%face_normal(SIZE(face_shape, 1), SIZE(face_nodes, 1), &
+         SIZE(elements, 1), 2))
+    ALLOCATE(this%face_region(SIZE(face_shape, 1), SIZE(face_nodes, 1), &
+         SIZE(elements, 1)))
+    ALLOCATE(face_coordinates(SIZE(face_nodes, 2), 2))
+    DO ielem = 1, SIZE(elements, 1)
+       DO iface = 1, SIZE(face_nodes, 1)
+          face_coordinates = node_coordinates(&
+               elements(ielem, face_nodes(iface, :)), 1:2)
+          DO igauss = 1, SIZE(face_shape, 1)
+             xy = MATMUL(face_shape(igauss, :), face_coordinates)
+             CALL geometry%evaluate_topology(xy(1), xy(2), &
+                  this%face_psi_normalized(igauss, iface, ielem), &
+                  this%face_rho(igauss, iface, ielem), &
+                  this%face_normal(igauss, iface, ielem, :), &
+                  this%face_region(igauss, iface, ielem))
+          ENDDO
+       ENDDO
+    ENDDO
+    DEALLOCATE(face_coordinates)
+
+    this%generation = this%generation + 1
+    this%equilibrium_generation = geometry%generation
+    this%is_initialized = .TRUE.
+  END SUBROUTINE magnetic_geometry_cache_build
+
+  SUBROUTINE magnetic_geometry_cache_clear(this)
+    CLASS(magnetic_geometry_cache_t), INTENT(INOUT) :: this
+
+    IF (ALLOCATED(this%nodal_psi_normalized)) DEALLOCATE(this%nodal_psi_normalized)
+    IF (ALLOCATED(this%nodal_rho)) DEALLOCATE(this%nodal_rho)
+    IF (ALLOCATED(this%nodal_normal)) DEALLOCATE(this%nodal_normal)
+    IF (ALLOCATED(this%nodal_region)) DEALLOCATE(this%nodal_region)
+    IF (ALLOCATED(this%volume_psi_normalized)) DEALLOCATE(this%volume_psi_normalized)
+    IF (ALLOCATED(this%volume_rho)) DEALLOCATE(this%volume_rho)
+    IF (ALLOCATED(this%volume_normal)) DEALLOCATE(this%volume_normal)
+    IF (ALLOCATED(this%volume_region)) DEALLOCATE(this%volume_region)
+    IF (ALLOCATED(this%face_psi_normalized)) DEALLOCATE(this%face_psi_normalized)
+    IF (ALLOCATED(this%face_rho)) DEALLOCATE(this%face_rho)
+    IF (ALLOCATED(this%face_normal)) DEALLOCATE(this%face_normal)
+    IF (ALLOCATED(this%face_region)) DEALLOCATE(this%face_region)
+    this%is_initialized = .FALSE.
+    this%equilibrium_generation = 0
+  END SUBROUTINE magnetic_geometry_cache_clear
+
+  SUBROUTINE set_restart_geometry_reference(psi_lcfs, r_axis, z_axis, a_minor)
+    REAL*8, INTENT(IN) :: psi_lcfs, r_axis, z_axis, a_minor
+
+    restart_reference_is_present = .TRUE.
+    restart_psi_lcfs = psi_lcfs
+    restart_r_axis = r_axis
+    restart_z_axis = z_axis
+    restart_a_minor = a_minor
+  END SUBROUTINE set_restart_geometry_reference
+
+  SUBROUTINE compare_restart_geometry(length_scale, mismatch, message)
+    REAL*8, INTENT(IN) :: length_scale
+    LOGICAL, INTENT(OUT) :: mismatch
+    CHARACTER(LEN=*), INTENT(OUT) :: message
+    REAL*8 :: psi_error, axis_error, a_error, current_r, current_z, current_a
+
+    mismatch = .FALSE.
+    message = ''
+    IF (.NOT. restart_reference_is_present) RETURN
+    restart_reference_is_present = .FALSE.
+
+    current_r = magnetic_equilibrium%r_axis*length_scale
+    current_z = magnetic_equilibrium%z_axis*length_scale
+    current_a = magnetic_equilibrium%a_minor*length_scale
+    psi_error = ABS(magnetic_equilibrium%psi_lcfs - restart_psi_lcfs)/ &
+         MAX(1.d0, ABS(magnetic_equilibrium%psi_lcfs), ABS(restart_psi_lcfs))
+    axis_error = HYPOT(current_r - restart_r_axis, current_z - restart_z_axis)/ &
+         MAX(1.d0, ABS(current_r), ABS(current_z), ABS(restart_r_axis), &
+         ABS(restart_z_axis))
+    a_error = ABS(current_a - restart_a_minor)/ &
+         MAX(1.d0, ABS(current_a), ABS(restart_a_minor))
+    mismatch = MAX(psi_error, axis_error, a_error) > restart_comparison_tolerance
+    IF (mismatch) THEN
+       WRITE(message, '(A,3(1X,ES10.3))') &
+            'Restart magnetic geometry differs (psi, axis, a):', &
+            psi_error, axis_error, a_error
+    ENDIF
+  END SUBROUTINE compare_restart_geometry
+
+END MODULE magnetic_geometry_state

--- a/src/Models/magnetic_geometry_state.f90
+++ b/src/Models/magnetic_geometry_state.f90
@@ -1,5 +1,6 @@
 MODULE magnetic_geometry_state
   USE, INTRINSIC :: ieee_arithmetic, ONLY: ieee_is_finite
+  USE prec_const, ONLY: PI
   USE magnetic_topology, ONLY: equilibrium_geometry_t
   IMPLICIT NONE
 
@@ -7,13 +8,34 @@ MODULE magnetic_geometry_state
 
   REAL*8, PARAMETER :: near_null_fraction = 1.d-6
   REAL*8, PARAMETER :: restart_comparison_tolerance = 1.d-6
+  REAL*8, PARAMETER :: vacuum_permeability = 4.d-7*PI
+  INTEGER, PARAMETER, PUBLIC :: field_alpha_plus_one = 1
+  INTEGER, PARAMETER, PUBLIC :: field_alpha_minus_one = 2
+  INTEGER, PARAMETER, PUBLIC :: field_alpha_plus_inverse_two_pi = 3
+  INTEGER, PARAMETER, PUBLIC :: field_alpha_minus_inverse_two_pi = 4
 
   TYPE, PUBLIC :: poloidal_field_fit_t
      LOGICAL :: is_valid = .FALSE.
      REAL*8 :: alpha = 0.d0
      REAL*8 :: relative_rms = HUGE(0.d0)
+     REAL*8 :: applied_alpha = 0.d0
+     REAL*8 :: applied_relative_rms = HUGE(0.d0)
+     REAL*8 :: canonical_relative_difference = HUGE(0.d0)
+     INTEGER :: convention_id = 0
      INTEGER :: sample_count = 0
   END TYPE poloidal_field_fit_t
+
+  TYPE, PUBLIC :: toroidal_current_comparison_t
+     LOGICAL :: is_valid = .FALSE.
+     INTEGER :: applied_sign = 1
+     REAL*8 :: core_raw_relative_l2 = 0.d0
+     REAL*8 :: core_relative_l2 = 0.d0
+     REAL*8 :: core_norm_ratio = 0.d0
+     REAL*8 :: core_best_scale = 0.d0
+     REAL*8 :: stored_outside_core_relative_l2 = 0.d0
+     INTEGER :: core_sample_count = 0
+     INTEGER :: outside_sample_count = 0
+  END TYPE toroidal_current_comparison_t
 
   TYPE, PUBLIC :: magnetic_geometry_cache_t
      LOGICAL :: is_initialized = .FALSE.
@@ -39,6 +61,8 @@ MODULE magnetic_geometry_state
   TYPE(equilibrium_geometry_t), SAVE, PUBLIC :: magnetic_equilibrium
   TYPE(magnetic_geometry_cache_t), SAVE, PUBLIC :: magnetic_geometry_cache
   TYPE(poloidal_field_fit_t), SAVE, PUBLIC :: poloidal_field_fit
+  TYPE(toroidal_current_comparison_t), SAVE, PUBLIC :: toroidal_current_comparison
+  LOGICAL, SAVE, PUBLIC :: toroidal_current_from_flux = .FALSE.
 
   LOGICAL, SAVE :: restart_reference_is_present = .FALSE.
   REAL*8, SAVE :: restart_psi_lcfs = 0.d0
@@ -47,6 +71,8 @@ MODULE magnetic_geometry_state
   REAL*8, SAVE :: restart_a_minor = 0.d0
 
   PUBLIC :: fit_poloidal_field_scale
+  PUBLIC :: fit_toroidal_current_sign
+  PUBLIC :: evaluate_flux_derived_toroidal_current
   PUBLIC :: reset_magnetic_geometry_state
   PUBLIC :: set_restart_geometry_reference
   PUBLIC :: compare_restart_geometry
@@ -57,6 +83,8 @@ CONTAINS
     CALL magnetic_equilibrium%clear()
     CALL magnetic_geometry_cache%clear()
     poloidal_field_fit = poloidal_field_fit_t()
+    toroidal_current_comparison = toroidal_current_comparison_t()
+    toroidal_current_from_flux = .FALSE.
   END SUBROUTINE reset_magnetic_geometry_state
 
   SUBROUTINE fit_poloidal_field_scale(geometry, r, z, br, bz, length_scale, fit)
@@ -65,10 +93,12 @@ CONTAINS
     REAL*8, INTENT(IN) :: br(:, :), bz(:, :)
     REAL*8, INTENT(IN) :: length_scale
     TYPE(poloidal_field_fit_t), INTENT(OUT) :: fit
-    INTEGER :: ir, iz
+    INTEGER :: ir, iz, candidate_index
     REAL*8 :: psi, psi_r, psi_z, gr, gz, gnorm, bnorm
     REAL*8 :: max_gnorm, max_bnorm, numerator, denominator
     REAL*8 :: residual, reference_norm, r_safe, length_scale_squared
+    REAL*8 :: applied_residual, inverse_two_pi
+    REAL*8 :: canonical_alpha(4)
 
     fit = poloidal_field_fit_t()
     IF (.NOT. geometry%is_initialized) RETURN
@@ -119,9 +149,70 @@ CONTAINS
     residual = MAX(reference_norm - 2.d0*fit%alpha*numerator + &
          fit%alpha*fit%alpha*denominator, 0.d0)
     fit%relative_rms = SQRT(residual/reference_norm)
+    inverse_two_pi = 1.d0/(2.d0*ACOS(-1.d0))
+    canonical_alpha = (/1.d0, -1.d0, inverse_two_pi, -inverse_two_pi/)
+    candidate_index = MINLOC(ABS(canonical_alpha - fit%alpha), DIM=1)
+    fit%convention_id = candidate_index
+    fit%applied_alpha = canonical_alpha(candidate_index)
+    fit%canonical_relative_difference = ABS(fit%alpha - fit%applied_alpha)/ &
+         ABS(fit%applied_alpha)
+    applied_residual = MAX(reference_norm - 2.d0*fit%applied_alpha*numerator + &
+         fit%applied_alpha*fit%applied_alpha*denominator, 0.d0)
+    fit%applied_relative_rms = SQRT(applied_residual/reference_norm)
     fit%is_valid = ieee_is_finite(fit%alpha) .AND. &
-         ieee_is_finite(fit%relative_rms)
+         ieee_is_finite(fit%relative_rms) .AND. &
+         ieee_is_finite(fit%applied_relative_rms) .AND. &
+         ieee_is_finite(fit%canonical_relative_difference)
   END SUBROUTINE fit_poloidal_field_scale
+
+  SUBROUTINE fit_toroidal_current_sign(derived_norm_squared, &
+       stored_norm_squared, cross_product, fit)
+    REAL*8, INTENT(IN) :: derived_norm_squared, stored_norm_squared
+    REAL*8, INTENT(IN) :: cross_product
+    TYPE(toroidal_current_comparison_t), INTENT(OUT) :: fit
+    REAL*8 :: applied_cross_product, raw_residual, applied_residual
+
+    fit = toroidal_current_comparison_t()
+    IF (.NOT. ieee_is_finite(derived_norm_squared) .OR. &
+         .NOT. ieee_is_finite(stored_norm_squared) .OR. &
+         .NOT. ieee_is_finite(cross_product)) RETURN
+    IF (derived_norm_squared <= TINY(1.d0) .OR. &
+         stored_norm_squared <= TINY(1.d0)) RETURN
+
+    IF (cross_product < 0.d0) fit%applied_sign = -1
+    applied_cross_product = REAL(fit%applied_sign, 8)*cross_product
+    raw_residual = MAX(derived_norm_squared + stored_norm_squared - &
+         2.d0*cross_product, 0.d0)
+    applied_residual = MAX(derived_norm_squared + stored_norm_squared - &
+         2.d0*applied_cross_product, 0.d0)
+
+    fit%is_valid = .TRUE.
+    fit%core_raw_relative_l2 = SQRT(raw_residual/stored_norm_squared)
+    fit%core_relative_l2 = SQRT(applied_residual/stored_norm_squared)
+    fit%core_norm_ratio = SQRT(derived_norm_squared/stored_norm_squared)
+    fit%core_best_scale = applied_cross_product/derived_norm_squared
+  END SUBROUTINE fit_toroidal_current_sign
+
+  SUBROUTINE evaluate_flux_derived_toroidal_current(geometry, r, z, &
+       length_scale, alpha, jtor, is_valid)
+    TYPE(equilibrium_geometry_t), INTENT(IN) :: geometry
+    REAL*8, INTENT(IN) :: r, z, length_scale, alpha
+    REAL*8, INTENT(OUT) :: jtor
+    LOGICAL, INTENT(OUT) :: is_valid
+    REAL*8 :: psi, psi_r, psi_z, psi_rr, psi_zz, psi_rz
+    REAL*8 :: grad_shafranov_psi
+
+    jtor = 0.d0
+    is_valid = .FALSE.
+    IF (.NOT. geometry%is_initialized .OR. length_scale <= 0.d0) RETURN
+    IF (ABS(r) <= 1.d-12) RETURN
+
+    CALL geometry%evaluate_flux(r, z, psi, psi_r, psi_z, psi_rr, psi_zz, psi_rz)
+    grad_shafranov_psi = psi_rr - psi_r/r + psi_zz
+    jtor = -alpha*grad_shafranov_psi/ &
+         (vacuum_permeability*r*length_scale**3)
+    is_valid = ieee_is_finite(jtor)
+  END SUBROUTINE evaluate_flux_derived_toroidal_current
 
   SUBROUTINE magnetic_geometry_cache_build(this, geometry, node_coordinates, &
        elements, volume_shape, face_nodes, face_shape)

--- a/src/Models/magnetic_topology.f90
+++ b/src/Models/magnetic_topology.f90
@@ -1,0 +1,857 @@
+MODULE magnetic_topology
+  USE interpolation, ONLY: build_bicubic_derivatives, &
+       eval_bicubic_with_derivatives, eval_bicubic_with_2nd_derivatives
+  IMPLICIT NONE
+
+  PRIVATE
+
+  INTEGER, PARAMETER, PUBLIC :: topology_unknown = 0
+  INTEGER, PARAMETER, PUBLIC :: topology_limited = 1
+  INTEGER, PARAMETER, PUBLIC :: topology_lower_single_null = 2
+
+  INTEGER, PARAMETER, PUBLIC :: lcfs_source_unknown = 0
+  INTEGER, PARAMETER, PUBLIC :: lcfs_source_wall = 1
+  INTEGER, PARAMETER, PUBLIC :: lcfs_source_xpoint = 2
+
+  INTEGER, PARAMETER, PUBLIC :: magnetic_region_undefined = 0
+  INTEGER, PARAMETER, PUBLIC :: magnetic_region_core = 1
+  INTEGER, PARAMETER, PUBLIC :: magnetic_region_main_sol = 2
+  INTEGER, PARAMETER, PUBLIC :: magnetic_region_private_flux = 3
+
+  INTEGER, PARAMETER :: max_critical_points = 64
+  INTEGER, PARAMETER :: lcfs_polygon_points = 720
+  INTEGER, PARAMETER :: ray_scan_points = 512
+  INTEGER, PARAMETER :: wall_samples_per_node = 6
+  INTEGER, PARAMETER :: newton_max_iterations = 30
+  REAL*8, PARAMETER :: geometry_tol = 1.d-12
+
+  TYPE :: critical_point_t
+     REAL*8 :: r = 0.d0
+     REAL*8 :: z = 0.d0
+     REAL*8 :: psi = 0.d0
+     REAL*8 :: hessian_det = 0.d0
+     LOGICAL :: elliptic = .FALSE.
+     LOGICAL :: saddle = .FALSE.
+  END TYPE critical_point_t
+
+  TYPE, PUBLIC :: equilibrium_geometry_t
+     LOGICAL :: is_initialized = .FALSE.
+     INTEGER :: nr = 0
+     INTEGER :: nz = 0
+     INTEGER :: generation = 0
+     INTEGER :: topology_kind = topology_unknown
+     INTEGER :: lcfs_source = lcfs_source_unknown
+     REAL*8 :: psi_sep_input = 0.d0
+     REAL*8 :: psi_axis = 0.d0
+     REAL*8 :: psi_lcfs = 0.d0
+     REAL*8 :: r_axis = 0.d0
+     REAL*8 :: z_axis = 0.d0
+     REAL*8 :: r_xpoint = 0.d0
+     REAL*8 :: z_xpoint = 0.d0
+     REAL*8 :: r_wall_contact = 0.d0
+     REAL*8 :: z_wall_contact = 0.d0
+     REAL*8 :: r_lcfs_min = 0.d0
+     REAL*8 :: r_lcfs_max = 0.d0
+     REAL*8 :: a_minor = 0.d0
+     REAL*8, ALLOCATABLE :: r(:)
+     REAL*8, ALLOCATABLE :: z(:)
+     REAL*8, ALLOCATABLE :: psi(:, :)
+     REAL*8, ALLOCATABLE :: psi_r(:, :)
+     REAL*8, ALLOCATABLE :: psi_z(:, :)
+     REAL*8, ALLOCATABLE :: psi_rz(:, :)
+     REAL*8, ALLOCATABLE :: lcfs_r(:)
+     REAL*8, ALLOCATABLE :: lcfs_z(:)
+   CONTAINS
+     PROCEDURE :: init => equilibrium_geometry_init
+     PROCEDURE :: analyze => equilibrium_geometry_analyze
+     PROCEDURE :: evaluate_flux => equilibrium_geometry_evaluate_flux
+     PROCEDURE :: evaluate_topology => equilibrium_geometry_evaluate_topology
+     PROCEDURE :: classify => equilibrium_geometry_classify
+     PROCEDURE :: clear => equilibrium_geometry_clear
+     FINAL :: equilibrium_geometry_finalize
+  END TYPE equilibrium_geometry_t
+
+CONTAINS
+
+  SUBROUTINE equilibrium_geometry_init(this, r, z, psi, ierr, message)
+    CLASS(equilibrium_geometry_t), INTENT(INOUT) :: this
+    REAL*8, INTENT(IN) :: r(:), z(:), psi(:, :)
+    INTEGER, INTENT(OUT) :: ierr
+    CHARACTER(LEN=*), INTENT(OUT) :: message
+
+    CALL this%clear()
+    ierr = 0
+    message = ''
+
+    IF (SIZE(r) < 4 .OR. SIZE(z) < 4) THEN
+       ierr = 1
+       message = 'Equilibrium grid needs at least four points in each direction'
+       RETURN
+    ENDIF
+    IF (SIZE(psi, 1) /= SIZE(z) .OR. SIZE(psi, 2) /= SIZE(r)) THEN
+       ierr = 2
+       message = 'Equilibrium psi dimensions do not match the coordinate vectors'
+       RETURN
+    ENDIF
+    IF (ANY(r(2:) <= r(:SIZE(r) - 1)) .OR. ANY(z(2:) <= z(:SIZE(z) - 1))) THEN
+       ierr = 3
+       message = 'Equilibrium coordinate vectors must be strictly increasing'
+       RETURN
+    ENDIF
+
+    this%nr = SIZE(r)
+    this%nz = SIZE(z)
+    ALLOCATE(this%r(this%nr), this%z(this%nz))
+    ALLOCATE(this%psi(this%nz, this%nr))
+    ALLOCATE(this%psi_r(this%nz, this%nr))
+    ALLOCATE(this%psi_z(this%nz, this%nr))
+    ALLOCATE(this%psi_rz(this%nz, this%nr))
+    this%r = r
+    this%z = z
+    this%psi = psi
+    CALL build_bicubic_derivatives(this%nz, this%z, this%nr, this%r, &
+         this%psi, this%psi_r, this%psi_z, this%psi_rz)
+    this%generation = this%generation + 1
+    this%is_initialized = .TRUE.
+  END SUBROUTINE equilibrium_geometry_init
+
+  SUBROUTINE equilibrium_geometry_clear(this)
+    CLASS(equilibrium_geometry_t), INTENT(INOUT) :: this
+
+    IF (ALLOCATED(this%r)) DEALLOCATE(this%r)
+    IF (ALLOCATED(this%z)) DEALLOCATE(this%z)
+    IF (ALLOCATED(this%psi)) DEALLOCATE(this%psi)
+    IF (ALLOCATED(this%psi_r)) DEALLOCATE(this%psi_r)
+    IF (ALLOCATED(this%psi_z)) DEALLOCATE(this%psi_z)
+    IF (ALLOCATED(this%psi_rz)) DEALLOCATE(this%psi_rz)
+    IF (ALLOCATED(this%lcfs_r)) DEALLOCATE(this%lcfs_r)
+    IF (ALLOCATED(this%lcfs_z)) DEALLOCATE(this%lcfs_z)
+    this%is_initialized = .FALSE.
+    this%nr = 0
+    this%nz = 0
+    this%topology_kind = topology_unknown
+    this%lcfs_source = lcfs_source_unknown
+    this%psi_sep_input = 0.d0
+    this%psi_axis = 0.d0
+    this%psi_lcfs = 0.d0
+    this%r_axis = 0.d0
+    this%z_axis = 0.d0
+    this%r_xpoint = 0.d0
+    this%z_xpoint = 0.d0
+    this%r_wall_contact = 0.d0
+    this%z_wall_contact = 0.d0
+    this%r_lcfs_min = 0.d0
+    this%r_lcfs_max = 0.d0
+    this%a_minor = 0.d0
+  END SUBROUTINE equilibrium_geometry_clear
+
+  SUBROUTINE equilibrium_geometry_finalize(this)
+    TYPE(equilibrium_geometry_t), INTENT(INOUT) :: this
+    CALL this%clear()
+  END SUBROUTINE equilibrium_geometry_finalize
+
+  SUBROUTINE equilibrium_geometry_analyze(this, psi_sep_input, wall_coordinates, &
+       wall_faces, wall_reference_nodes, ierr, message)
+    CLASS(equilibrium_geometry_t), INTENT(INOUT) :: this
+    REAL*8, INTENT(IN) :: psi_sep_input
+    REAL*8, INTENT(IN) :: wall_coordinates(:, :)
+    INTEGER, INTENT(IN) :: wall_faces(:, :)
+    REAL*8, INTENT(IN) :: wall_reference_nodes(:)
+    INTEGER, INTENT(OUT) :: ierr
+    CHARACTER(LEN=*), INTENT(OUT) :: message
+    TYPE(critical_point_t) :: points(max_critical_points)
+    INTEGER :: npoints, iaxis, ixpoint
+    REAL*8 :: psi_wall, x_seed_error, span_seed, outward_sign
+    REAL*8 :: wall_event_delta, x_event_delta, event_tolerance
+    LOGICAL :: wall_found
+
+    ierr = 0
+    message = ''
+    IF (.NOT. this%is_initialized) THEN
+       ierr = 10
+       message = 'Equilibrium geometry has not been initialized'
+       RETURN
+    ENDIF
+    IF (SIZE(wall_coordinates, 2) /= 2 .OR. &
+         SIZE(wall_faces, 2) /= SIZE(wall_reference_nodes)) THEN
+       ierr = 11
+       message = 'Wall coordinates/connectivity/reference nodes are inconsistent'
+       RETURN
+    ENDIF
+    IF (SIZE(wall_faces, 1) <= 0) THEN
+       ierr = 12
+       message = 'A non-periodic physical wall is required for LCFS analysis'
+       RETURN
+    ENDIF
+
+    this%psi_sep_input = psi_sep_input
+    CALL find_critical_points(this, wall_coordinates, wall_faces, &
+         wall_reference_nodes, points, npoints, ierr, message)
+    IF (ierr /= 0) RETURN
+
+    CALL select_axis(points, npoints, iaxis, ierr, message)
+    IF (ierr /= 0) RETURN
+    this%r_axis = points(iaxis)%r
+    this%z_axis = points(iaxis)%z
+    this%psi_axis = points(iaxis)%psi
+
+    span_seed = psi_sep_input - this%psi_axis
+    IF (ABS(span_seed) <= geometry_tol*MAX(1.d0, ABS(this%psi_axis))) THEN
+       ierr = 13
+       message = 'Input psiSep is indistinguishable from the magnetic-axis flux'
+       RETURN
+    ENDIF
+
+    outward_sign = SIGN(1.d0, span_seed)
+    CALL select_lower_xpoint(this, points, npoints, span_seed, ixpoint, x_seed_error)
+    CALL find_wall_contact(this, wall_coordinates, wall_faces, wall_reference_nodes, &
+         outward_sign, psi_wall, this%r_wall_contact, &
+         this%z_wall_contact, wall_found)
+
+    wall_event_delta = HUGE(0.d0)
+    IF (wall_found) wall_event_delta = outward_sign*(psi_wall - this%psi_axis)
+    x_event_delta = HUGE(0.d0)
+    IF (ixpoint > 0) x_event_delta = outward_sign*(points(ixpoint)%psi - this%psi_axis)
+    event_tolerance = 1.d-6*ABS(span_seed)
+
+    ! Candidate events have already been checked against the axis-connected
+    ! component.  Their signed flux distance can therefore order which event
+    ! is reached first without confusing equal-flux private-flux components.
+    IF (ixpoint > 0 .AND. x_event_delta <= wall_event_delta + event_tolerance) THEN
+       this%topology_kind = topology_lower_single_null
+       this%lcfs_source = lcfs_source_xpoint
+       this%r_xpoint = points(ixpoint)%r
+       this%z_xpoint = points(ixpoint)%z
+       this%psi_lcfs = points(ixpoint)%psi
+    ELSEIF (wall_found) THEN
+       this%topology_kind = topology_limited
+       this%lcfs_source = lcfs_source_wall
+       this%psi_lcfs = psi_wall
+    ELSEIF (ixpoint > 0) THEN
+       this%topology_kind = topology_lower_single_null
+       this%lcfs_source = lcfs_source_xpoint
+       this%r_xpoint = points(ixpoint)%r
+       this%z_xpoint = points(ixpoint)%z
+       this%psi_lcfs = points(ixpoint)%psi
+    ELSE
+       ierr = 14
+       message = 'Could not identify either a wall-limited LCFS or a lower X-point'
+       RETURN
+    ENDIF
+
+    IF (ABS(this%psi_lcfs - this%psi_axis) <= &
+         geometry_tol*MAX(1.d0, ABS(this%psi_axis))) THEN
+       ierr = 15
+       message = 'Detected LCFS has zero flux span from the magnetic axis'
+       RETURN
+    ENDIF
+
+    CALL build_axis_connected_lcfs(this, ierr, message)
+    IF (ierr /= 0) RETURN
+    CALL refine_lcfs_radial_extrema(this)
+    this%a_minor = 0.5d0*(this%r_lcfs_max - this%r_lcfs_min)
+    IF (this%a_minor <= geometry_tol) THEN
+       ierr = 16
+       message = 'Detected LCFS has a non-positive minor radius'
+    ENDIF
+  END SUBROUTINE equilibrium_geometry_analyze
+
+  SUBROUTINE equilibrium_geometry_evaluate_flux(this, r, z, psi, dpsi_dr, &
+       dpsi_dz, d2psi_dr2, d2psi_dz2, d2psi_drdz)
+    CLASS(equilibrium_geometry_t), INTENT(IN) :: this
+    REAL*8, INTENT(IN) :: r, z
+    REAL*8, INTENT(OUT) :: psi, dpsi_dr, dpsi_dz
+    REAL*8, INTENT(OUT), OPTIONAL :: d2psi_dr2, d2psi_dz2, d2psi_drdz
+    REAL*8 :: drr, dzz, drz
+
+    IF (PRESENT(d2psi_dr2) .OR. PRESENT(d2psi_dz2) .OR. PRESENT(d2psi_drdz)) THEN
+       CALL eval_bicubic_with_2nd_derivatives(this%nz, this%z, this%nr, this%r, &
+            this%psi, this%psi_r, this%psi_z, this%psi_rz, z, r, psi, &
+            dpsi_dz, dpsi_dr, dzz, drr, drz)
+       IF (PRESENT(d2psi_dr2)) d2psi_dr2 = drr
+       IF (PRESENT(d2psi_dz2)) d2psi_dz2 = dzz
+       IF (PRESENT(d2psi_drdz)) d2psi_drdz = drz
+    ELSE
+       CALL eval_bicubic_with_derivatives(this%nz, this%z, this%nr, this%r, &
+            this%psi, this%psi_r, this%psi_z, this%psi_rz, z, r, psi, &
+            dpsi_dz, dpsi_dr)
+    ENDIF
+  END SUBROUTINE equilibrium_geometry_evaluate_flux
+
+  SUBROUTINE equilibrium_geometry_evaluate_topology(this, r, z, psi_normalized, rho, &
+       outward_normal, region)
+    CLASS(equilibrium_geometry_t), INTENT(IN) :: this
+    REAL*8, INTENT(IN) :: r, z
+    REAL*8, INTENT(OUT) :: psi_normalized, rho, outward_normal(2)
+    INTEGER, INTENT(OUT) :: region
+    REAL*8 :: psi, dpsi_dr, dpsi_dz, span, norm_grad
+
+    CALL this%evaluate_flux(r, z, psi, dpsi_dr, dpsi_dz)
+    span = this%psi_lcfs - this%psi_axis
+    psi_normalized = (psi - this%psi_axis)/span
+    rho = SQRT(MAX(psi_normalized, 0.d0))
+    outward_normal = SIGN(1.d0, span)*(/dpsi_dr, dpsi_dz/)
+    norm_grad = NORM2(outward_normal)
+    IF (norm_grad > geometry_tol) THEN
+       outward_normal = outward_normal/norm_grad
+    ELSE
+       outward_normal = 0.d0
+    ENDIF
+    region = this%classify(r, z, psi_normalized)
+  END SUBROUTINE equilibrium_geometry_evaluate_topology
+
+  INTEGER FUNCTION equilibrium_geometry_classify(this, r, z, psi_normalized)
+    CLASS(equilibrium_geometry_t), INTENT(IN) :: this
+    REAL*8, INTENT(IN) :: r, z, psi_normalized
+
+    equilibrium_geometry_classify = magnetic_region_undefined
+    IF (.NOT. this%is_initialized .OR. .NOT. ALLOCATED(this%lcfs_r)) RETURN
+    IF (point_in_polygon(r, z, this%lcfs_r, this%lcfs_z)) THEN
+       equilibrium_geometry_classify = magnetic_region_core
+    ELSEIF (psi_normalized < 1.d0) THEN
+       equilibrium_geometry_classify = magnetic_region_private_flux
+    ELSE
+       equilibrium_geometry_classify = magnetic_region_main_sol
+    ENDIF
+  END FUNCTION equilibrium_geometry_classify
+
+  SUBROUTINE find_critical_points(this, wall_coordinates, wall_faces, &
+       wall_reference_nodes, points, npoints, ierr, message)
+    CLASS(equilibrium_geometry_t), INTENT(IN) :: this
+    REAL*8, INTENT(IN) :: wall_coordinates(:, :), wall_reference_nodes(:)
+    INTEGER, INTENT(IN) :: wall_faces(:, :)
+    TYPE(critical_point_t), INTENT(OUT) :: points(max_critical_points)
+    INTEGER, INTENT(OUT) :: npoints, ierr
+    CHARACTER(LEN=*), INTENT(OUT) :: message
+    INTEGER :: ir, iz
+    REAL*8 :: gr(4), gz(4), r0, z0
+    TYPE(critical_point_t) :: point
+    LOGICAL :: converged
+
+    npoints = 0
+    ierr = 0
+    message = ''
+    DO iz = 1, this%nz - 1
+       DO ir = 1, this%nr - 1
+          gr = (/this%psi_r(iz, ir), this%psi_r(iz, ir + 1), &
+               this%psi_r(iz + 1, ir), this%psi_r(iz + 1, ir + 1)/)
+          gz = (/this%psi_z(iz, ir), this%psi_z(iz, ir + 1), &
+               this%psi_z(iz + 1, ir), this%psi_z(iz + 1, ir + 1)/)
+          IF (MINVAL(gr) > 0.d0 .OR. MAXVAL(gr) < 0.d0) CYCLE
+          IF (MINVAL(gz) > 0.d0 .OR. MAXVAL(gz) < 0.d0) CYCLE
+          r0 = 0.5d0*(this%r(ir) + this%r(ir + 1))
+          z0 = 0.5d0*(this%z(iz) + this%z(iz + 1))
+          CALL refine_critical_point(this, r0, z0, point, converged)
+          IF (.NOT. converged) CYCLE
+          IF (.NOT. point_inside_wall(point%r, point%z, wall_coordinates, &
+               wall_faces, wall_reference_nodes)) CYCLE
+          IF (critical_point_is_duplicate(this, points, npoints, point)) CYCLE
+          IF (npoints >= max_critical_points) THEN
+             ierr = 20
+             message = 'Too many magnetic critical points for supported topology'
+             RETURN
+          ENDIF
+          npoints = npoints + 1
+          points(npoints) = point
+       ENDDO
+    ENDDO
+    IF (npoints == 0) THEN
+       ierr = 21
+       message = 'No magnetic critical point was found inside the physical wall'
+    ENDIF
+  END SUBROUTINE find_critical_points
+
+  SUBROUTINE refine_critical_point(this, r, z, point, converged)
+    CLASS(equilibrium_geometry_t), INTENT(IN) :: this
+    REAL*8, INTENT(IN) :: r, z
+    TYPE(critical_point_t), INTENT(OUT) :: point
+    LOGICAL, INTENT(OUT) :: converged
+    INTEGER :: iteration
+    REAL*8 :: rr, zz, psi, pr, pz, prr, pzz, prz, det, dr, dz
+    REAL*8 :: grad_scale, domain_scale
+
+    rr = r
+    zz = z
+    converged = .FALSE.
+    domain_scale = MAX(this%r(this%nr) - this%r(1), this%z(this%nz) - this%z(1))
+    DO iteration = 1, newton_max_iterations
+       CALL this%evaluate_flux(rr, zz, psi, pr, pz, prr, pzz, prz)
+       det = prr*pzz - prz*prz
+       IF (ABS(det) <= geometry_tol) RETURN
+       dr = (-pr*pzz + pz*prz)/det
+       dz = (-pz*prr + pr*prz)/det
+       rr = MIN(MAX(rr + dr, this%r(1)), this%r(this%nr))
+       zz = MIN(MAX(zz + dz, this%z(1)), this%z(this%nz))
+       grad_scale = MAX(1.d0, ABS(psi)/MAX(domain_scale, geometry_tol))
+       IF (SQRT(pr*pr + pz*pz) <= 1.d-9*grad_scale .AND. &
+            SQRT(dr*dr + dz*dz) <= 1.d-9*domain_scale) THEN
+          converged = .TRUE.
+          EXIT
+       ENDIF
+    ENDDO
+    IF (.NOT. converged) RETURN
+
+    CALL this%evaluate_flux(rr, zz, psi, pr, pz, prr, pzz, prz)
+    point%r = rr
+    point%z = zz
+    point%psi = psi
+    point%hessian_det = prr*pzz - prz*prz
+    point%elliptic = point%hessian_det > geometry_tol
+    point%saddle = point%hessian_det < -geometry_tol
+  END SUBROUTINE refine_critical_point
+
+  LOGICAL FUNCTION critical_point_is_duplicate(this, points, npoints, point)
+    CLASS(equilibrium_geometry_t), INTENT(IN) :: this
+    TYPE(critical_point_t), INTENT(IN) :: points(max_critical_points), point
+    INTEGER, INTENT(IN) :: npoints
+    INTEGER :: i
+    REAL*8 :: tolerance
+
+    critical_point_is_duplicate = .FALSE.
+    tolerance = 1.d-6*MAX(this%r(this%nr) - this%r(1), &
+         this%z(this%nz) - this%z(1))
+    DO i = 1, npoints
+       IF (HYPOT(points(i)%r - point%r, points(i)%z - point%z) <= tolerance) THEN
+          critical_point_is_duplicate = .TRUE.
+          RETURN
+       ENDIF
+    ENDDO
+  END FUNCTION critical_point_is_duplicate
+
+  SUBROUTINE select_axis(points, npoints, iaxis, ierr, message)
+    TYPE(critical_point_t), INTENT(IN) :: points(max_critical_points)
+    INTEGER, INTENT(IN) :: npoints
+    INTEGER, INTENT(OUT) :: iaxis, ierr
+    CHARACTER(LEN=*), INTENT(OUT) :: message
+    INTEGER :: i, count_axis
+
+    iaxis = 0
+    count_axis = 0
+    ierr = 0
+    message = ''
+    DO i = 1, npoints
+       IF (.NOT. points(i)%elliptic) CYCLE
+       count_axis = count_axis + 1
+       iaxis = i
+    ENDDO
+    IF (count_axis == 0) THEN
+       ierr = 22
+       message = 'No elliptic magnetic axis was found inside the physical wall'
+    ELSEIF (count_axis > 1) THEN
+       ierr = 23
+       message = 'Multiple magnetic axes are outside the supported PR03 topology'
+    ENDIF
+  END SUBROUTINE select_axis
+
+  SUBROUTINE select_lower_xpoint(this, points, npoints, span_seed, ixpoint, score)
+    CLASS(equilibrium_geometry_t), INTENT(IN) :: this
+    TYPE(critical_point_t), INTENT(IN) :: points(max_critical_points)
+    INTEGER, INTENT(IN) :: npoints
+    REAL*8, INTENT(IN) :: span_seed
+    INTEGER, INTENT(OUT) :: ixpoint
+    REAL*8, INTENT(OUT) :: score
+    INTEGER :: i
+    REAL*8 :: candidate_score, theta, radius, distance, domain_scale
+    LOGICAL :: connected
+
+    ixpoint = 0
+    score = HUGE(0.d0)
+    domain_scale = MAX(this%r(this%nr) - this%r(1), &
+         this%z(this%nz) - this%z(1))
+    DO i = 1, npoints
+       IF (.NOT. points(i)%saddle) CYCLE
+       IF (points(i)%z >= this%z_axis) CYCLE
+       IF (SIGN(1.d0, span_seed)*(points(i)%psi - this%psi_axis) <= geometry_tol) CYCLE
+       theta = ATAN2(points(i)%z - this%z_axis, points(i)%r - this%r_axis)
+       distance = HYPOT(points(i)%r - this%r_axis, points(i)%z - this%z_axis)
+       CALL first_level_crossing(this, points(i)%psi, theta, radius, connected)
+       IF (.NOT. connected) CYCLE
+       IF (ABS(radius - distance) > 1.d-5*domain_scale) CYCLE
+       candidate_score = ABS((points(i)%psi - this%psi_sep_input)/span_seed)
+       IF (candidate_score < score) THEN
+          ixpoint = i
+          score = candidate_score
+       ENDIF
+    ENDDO
+  END SUBROUTINE select_lower_xpoint
+
+  SUBROUTINE find_wall_contact(this, wall_coordinates, wall_faces, wall_reference_nodes, &
+       outward_sign, psi_contact, r_contact, z_contact, found)
+    CLASS(equilibrium_geometry_t), INTENT(IN) :: this
+    REAL*8, INTENT(IN) :: wall_coordinates(:, :), wall_reference_nodes(:)
+    INTEGER, INTENT(IN) :: wall_faces(:, :)
+    REAL*8, INTENT(IN) :: outward_sign
+    REAL*8, INTENT(OUT) :: psi_contact, r_contact, z_contact
+    LOGICAL, INTENT(OUT) :: found
+    INTEGER :: iface, isample, nsample
+    REAL*8 :: s0, s1, s2, f0, f1, f2, smin, fmin, r, z, psi, pr, pz
+    REAL*8 :: best_delta, delta
+
+    found = .FALSE.
+    best_delta = HUGE(0.d0)
+    psi_contact = 0.d0
+    r_contact = 0.d0
+    z_contact = 0.d0
+    nsample = MAX(12, wall_samples_per_node*SIZE(wall_reference_nodes))
+
+    DO iface = 1, SIZE(wall_faces, 1)
+       s0 = -1.d0
+       CALL wall_flux(this, wall_coordinates, wall_faces(iface, :), &
+            wall_reference_nodes, s0, outward_sign, f0, r, z, psi)
+       CALL consider_wall_candidate(f0, r, z, psi)
+       s1 = -1.d0 + 2.d0/REAL(nsample)
+       CALL wall_flux(this, wall_coordinates, wall_faces(iface, :), &
+            wall_reference_nodes, s1, outward_sign, f1, r, z, psi)
+       CALL consider_wall_candidate(f1, r, z, psi)
+       DO isample = 2, nsample
+          s2 = -1.d0 + 2.d0*REAL(isample)/REAL(nsample)
+          CALL wall_flux(this, wall_coordinates, wall_faces(iface, :), &
+               wall_reference_nodes, s2, outward_sign, f2, r, z, psi)
+          CALL consider_wall_candidate(f2, r, z, psi)
+          IF (f1 <= f0 .AND. f1 <= f2) THEN
+             CALL minimize_wall_interval(this, wall_coordinates, wall_faces(iface, :), &
+                  wall_reference_nodes, outward_sign, s0, s2, smin, fmin)
+             CALL wall_flux(this, wall_coordinates, wall_faces(iface, :), &
+                  wall_reference_nodes, smin, outward_sign, delta, r, z, psi)
+             CALL consider_wall_candidate(delta, r, z, psi)
+          ENDIF
+          s0 = s1
+          f0 = f1
+          s1 = s2
+          f1 = f2
+       ENDDO
+    ENDDO
+
+  CONTAINS
+    SUBROUTINE consider_wall_candidate(candidate_delta, candidate_r, candidate_z, candidate_psi)
+      REAL*8, INTENT(IN) :: candidate_delta, candidate_r, candidate_z, candidate_psi
+      REAL*8 :: theta, radius, distance, domain_scale
+      LOGICAL :: connected
+      IF (candidate_delta <= geometry_tol) RETURN
+      theta = ATAN2(candidate_z - this%z_axis, candidate_r - this%r_axis)
+      distance = HYPOT(candidate_r - this%r_axis, candidate_z - this%z_axis)
+      CALL first_level_crossing(this, candidate_psi, theta, radius, connected)
+      IF (.NOT. connected) RETURN
+      domain_scale = MAX(this%r(this%nr) - this%r(1), &
+           this%z(this%nz) - this%z(1))
+      IF (ABS(radius - distance) > 1.d-5*domain_scale) RETURN
+      IF (candidate_delta < best_delta) THEN
+         best_delta = candidate_delta
+         psi_contact = candidate_psi
+         r_contact = candidate_r
+         z_contact = candidate_z
+         found = .TRUE.
+      ENDIF
+    END SUBROUTINE consider_wall_candidate
+  END SUBROUTINE find_wall_contact
+
+  SUBROUTINE minimize_wall_interval(this, wall_coordinates, wall_face, &
+       wall_reference_nodes, outward_sign, sa, sb, smin, fmin)
+    CLASS(equilibrium_geometry_t), INTENT(IN) :: this
+    REAL*8, INTENT(IN) :: wall_coordinates(:, :), wall_reference_nodes(:)
+    INTEGER, INTENT(IN) :: wall_face(:)
+    REAL*8, INTENT(IN) :: outward_sign, sa, sb
+    REAL*8, INTENT(OUT) :: smin, fmin
+    INTEGER :: iteration
+    REAL*8, PARAMETER :: golden = 0.6180339887498948482d0
+    REAL*8 :: left, right, s1, s2, f1, f2, r, z, psi
+
+    left = sa
+    right = sb
+    s1 = right - golden*(right - left)
+    s2 = left + golden*(right - left)
+    CALL wall_flux(this, wall_coordinates, wall_face, wall_reference_nodes, &
+         s1, outward_sign, f1, r, z, psi)
+    CALL wall_flux(this, wall_coordinates, wall_face, wall_reference_nodes, &
+         s2, outward_sign, f2, r, z, psi)
+    DO iteration = 1, 50
+       IF (f1 <= f2) THEN
+          right = s2
+          s2 = s1
+          f2 = f1
+          s1 = right - golden*(right - left)
+          CALL wall_flux(this, wall_coordinates, wall_face, wall_reference_nodes, &
+               s1, outward_sign, f1, r, z, psi)
+       ELSE
+          left = s1
+          s1 = s2
+          f1 = f2
+          s2 = left + golden*(right - left)
+          CALL wall_flux(this, wall_coordinates, wall_face, wall_reference_nodes, &
+               s2, outward_sign, f2, r, z, psi)
+       ENDIF
+       IF (ABS(right - left) <= 1.d-12) EXIT
+    ENDDO
+    IF (f1 <= f2) THEN
+       smin = s1
+       fmin = f1
+    ELSE
+       smin = s2
+       fmin = f2
+    ENDIF
+  END SUBROUTINE minimize_wall_interval
+
+  SUBROUTINE wall_flux(this, wall_coordinates, wall_face, wall_reference_nodes, &
+       s, outward_sign, delta, r, z, psi)
+    CLASS(equilibrium_geometry_t), INTENT(IN) :: this
+    REAL*8, INTENT(IN) :: wall_coordinates(:, :), wall_reference_nodes(:)
+    INTEGER, INTENT(IN) :: wall_face(:)
+    REAL*8, INTENT(IN) :: s, outward_sign
+    REAL*8, INTENT(OUT) :: delta, r, z, psi
+    REAL*8 :: drds, dzds, pr, pz
+
+    CALL evaluate_wall_position(wall_coordinates, wall_face, wall_reference_nodes, &
+         s, r, z, drds, dzds)
+    CALL this%evaluate_flux(r, z, psi, pr, pz)
+    delta = outward_sign*(psi - this%psi_axis)
+  END SUBROUTINE wall_flux
+
+  SUBROUTINE evaluate_wall_position(wall_coordinates, wall_face, reference_nodes, &
+       s, r, z, drds, dzds)
+    REAL*8, INTENT(IN) :: wall_coordinates(:, :), reference_nodes(:), s
+    INTEGER, INTENT(IN) :: wall_face(:)
+    REAL*8, INTENT(OUT) :: r, z, drds, dzds
+    INTEGER :: i, j, k, n
+    REAL*8 :: basis, derivative, product
+
+    n = SIZE(reference_nodes)
+    r = 0.d0
+    z = 0.d0
+    drds = 0.d0
+    dzds = 0.d0
+    DO i = 1, n
+       basis = 1.d0
+       DO j = 1, n
+          IF (j == i) CYCLE
+          basis = basis*(s - reference_nodes(j))/(reference_nodes(i) - reference_nodes(j))
+       ENDDO
+       derivative = 0.d0
+       DO k = 1, n
+          IF (k == i) CYCLE
+          product = 1.d0/(reference_nodes(i) - reference_nodes(k))
+          DO j = 1, n
+             IF (j == i .OR. j == k) CYCLE
+             product = product*(s - reference_nodes(j))/(reference_nodes(i) - reference_nodes(j))
+          ENDDO
+          derivative = derivative + product
+       ENDDO
+       r = r + basis*wall_coordinates(wall_face(i), 1)
+       z = z + basis*wall_coordinates(wall_face(i), 2)
+       drds = drds + derivative*wall_coordinates(wall_face(i), 1)
+       dzds = dzds + derivative*wall_coordinates(wall_face(i), 2)
+    ENDDO
+  END SUBROUTINE evaluate_wall_position
+
+  LOGICAL FUNCTION point_inside_wall(r, z, wall_coordinates, wall_faces, reference_nodes)
+    REAL*8, INTENT(IN) :: r, z, wall_coordinates(:, :), reference_nodes(:)
+    INTEGER, INTENT(IN) :: wall_faces(:, :)
+    INTEGER :: iface, isample, nsample
+    REAL*8 :: s, r0, z0, r1, z1, drds, dzds, intersection_r
+
+    point_inside_wall = .FALSE.
+    nsample = MAX(8, 3*SIZE(reference_nodes))
+    DO iface = 1, SIZE(wall_faces, 1)
+       CALL evaluate_wall_position(wall_coordinates, wall_faces(iface, :), &
+            reference_nodes, -1.d0, r0, z0, drds, dzds)
+       DO isample = 1, nsample
+          s = -1.d0 + 2.d0*REAL(isample)/REAL(nsample)
+          CALL evaluate_wall_position(wall_coordinates, wall_faces(iface, :), &
+               reference_nodes, s, r1, z1, drds, dzds)
+          IF ((z0 > z) .NEQV. (z1 > z)) THEN
+             intersection_r = r0 + (z - z0)*(r1 - r0)/(z1 - z0)
+             IF (intersection_r > r) point_inside_wall = .NOT. point_inside_wall
+          ENDIF
+          r0 = r1
+          z0 = z1
+       ENDDO
+    ENDDO
+  END FUNCTION point_inside_wall
+
+  SUBROUTINE build_axis_connected_lcfs(this, ierr, message)
+    CLASS(equilibrium_geometry_t), INTENT(INOUT) :: this
+    INTEGER, INTENT(OUT) :: ierr
+    CHARACTER(LEN=*), INTENT(OUT) :: message
+    INTEGER :: i
+    REAL*8 :: theta, radius
+    LOGICAL :: found
+
+    ierr = 0
+    message = ''
+    IF (ALLOCATED(this%lcfs_r)) DEALLOCATE(this%lcfs_r)
+    IF (ALLOCATED(this%lcfs_z)) DEALLOCATE(this%lcfs_z)
+    ALLOCATE(this%lcfs_r(lcfs_polygon_points), this%lcfs_z(lcfs_polygon_points))
+
+    DO i = 1, lcfs_polygon_points
+       theta = 2.d0*ACOS(-1.d0)*REAL(i - 1)/REAL(lcfs_polygon_points)
+       CALL first_lcfs_crossing(this, theta, radius, found)
+       IF (.NOT. found) THEN
+          ierr = 30
+          WRITE(message, '(A,I0,A)') 'Axis-connected LCFS was not found on radial ray ', i, &
+               '; unsupported non-star-shaped or inconsistent topology'
+          RETURN
+       ENDIF
+       this%lcfs_r(i) = this%r_axis + radius*COS(theta)
+       this%lcfs_z(i) = this%z_axis + radius*SIN(theta)
+    ENDDO
+  END SUBROUTINE build_axis_connected_lcfs
+
+  SUBROUTINE first_lcfs_crossing(this, theta, radius, found)
+    CLASS(equilibrium_geometry_t), INTENT(IN) :: this
+    REAL*8, INTENT(IN) :: theta
+    REAL*8, INTENT(OUT) :: radius
+    LOGICAL, INTENT(OUT) :: found
+    CALL first_level_crossing(this, this%psi_lcfs, theta, radius, found)
+  END SUBROUTINE first_lcfs_crossing
+
+  SUBROUTINE first_level_crossing(this, psi_level, theta, radius, found)
+    CLASS(equilibrium_geometry_t), INTENT(IN) :: this
+    REAL*8, INTENT(IN) :: psi_level, theta
+    REAL*8, INTENT(OUT) :: radius
+    LOGICAL, INTENT(OUT) :: found
+    INTEGER :: i, iteration, imax
+    REAL*8 :: c, s, rmax, t0, t1, f0, f1, tm, fm, psi, pr, pz
+    REAL*8 :: prr, pzz, prz, dfdt, d2fdt2, tleft, tright, dt
+    REAL*8 :: signed_span, max_f
+
+    c = COS(theta)
+    s = SIN(theta)
+    rmax = ray_limit(this, c, s)
+    signed_span = SIGN(1.d0, psi_level - this%psi_axis)
+    t0 = 0.d0
+    f0 = -ABS(psi_level - this%psi_axis)
+    max_f = f0
+    imax = 0
+    found = .FALSE.
+    radius = 0.d0
+
+    DO i = 1, ray_scan_points
+       t1 = rmax*REAL(i)/REAL(ray_scan_points)
+       CALL this%evaluate_flux(this%r_axis + t1*c, this%z_axis + t1*s, psi, pr, pz)
+       f1 = signed_span*(psi - psi_level)
+       IF (f1 > max_f) THEN
+          max_f = f1
+          imax = i
+       ENDIF
+       IF (f1 >= 0.d0) THEN
+          DO iteration = 1, 60
+             tm = 0.5d0*(t0 + t1)
+             CALL this%evaluate_flux(this%r_axis + tm*c, this%z_axis + tm*s, psi, pr, pz)
+             fm = signed_span*(psi - psi_level)
+             IF (fm >= 0.d0) THEN
+                t1 = tm
+             ELSE
+                t0 = tm
+             ENDIF
+          ENDDO
+          radius = 0.5d0*(t0 + t1)
+          found = .TRUE.
+          RETURN
+       ENDIF
+       t0 = t1
+       f0 = f1
+    ENDDO
+
+    IF (imax <= 0) RETURN
+
+    ! At an X point the separatrix can merely touch a radial ray, so a sign
+    ! change is not guaranteed.  Refine the sampled maximum of psi along the
+    ! ray before deciding whether this is that tangential LCFS contact.
+    dt = rmax/REAL(ray_scan_points)
+    tleft = MAX(0.d0, REAL(imax - 1)*dt)
+    tright = MIN(rmax, REAL(imax + 1)*dt)
+    tm = REAL(imax)*dt
+    DO iteration = 1, newton_max_iterations
+       CALL this%evaluate_flux(this%r_axis + tm*c, this%z_axis + tm*s, psi, &
+            pr, pz, prr, pzz, prz)
+       dfdt = signed_span*(pr*c + pz*s)
+       d2fdt2 = signed_span*(prr*c*c + 2.d0*prz*c*s + pzz*s*s)
+       IF (ABS(d2fdt2) <= geometry_tol) EXIT
+       t1 = MIN(MAX(tm - dfdt/d2fdt2, tleft), tright)
+       IF (ABS(t1 - tm) <= 1.d-13*MAX(1.d0, rmax)) THEN
+          tm = t1
+          EXIT
+       ENDIF
+       tm = t1
+    ENDDO
+    CALL this%evaluate_flux(this%r_axis + tm*c, this%z_axis + tm*s, psi, pr, pz)
+    fm = signed_span*(psi - psi_level)
+    IF (ABS(fm) <= 1.d-7*ABS(psi_level - this%psi_axis)) THEN
+       radius = tm
+       found = .TRUE.
+    ENDIF
+  END SUBROUTINE first_level_crossing
+
+  REAL*8 FUNCTION ray_limit(this, c, s)
+    CLASS(equilibrium_geometry_t), INTENT(IN) :: this
+    REAL*8, INTENT(IN) :: c, s
+    REAL*8 :: tr, tz
+
+    tr = HUGE(0.d0)
+    tz = HUGE(0.d0)
+    IF (c > geometry_tol) tr = (this%r(this%nr) - this%r_axis)/c
+    IF (c < -geometry_tol) tr = (this%r(1) - this%r_axis)/c
+    IF (s > geometry_tol) tz = (this%z(this%nz) - this%z_axis)/s
+    IF (s < -geometry_tol) tz = (this%z(1) - this%z_axis)/s
+    ray_limit = 0.999999d0*MIN(tr, tz)
+  END FUNCTION ray_limit
+
+  SUBROUTINE refine_lcfs_radial_extrema(this)
+    CLASS(equilibrium_geometry_t), INTENT(INOUT) :: this
+    INTEGER :: imin(1), imax(1)
+    REAL*8 :: rmin, zmin, rmax, zmax
+    LOGICAL :: okmin, okmax
+
+    imin = MINLOC(this%lcfs_r)
+    imax = MAXLOC(this%lcfs_r)
+    rmin = this%lcfs_r(imin(1))
+    zmin = this%lcfs_z(imin(1))
+    rmax = this%lcfs_r(imax(1))
+    zmax = this%lcfs_z(imax(1))
+    CALL refine_radial_extremum(this, rmin, zmin, okmin)
+    CALL refine_radial_extremum(this, rmax, zmax, okmax)
+    this%r_lcfs_min = rmin
+    this%r_lcfs_max = rmax
+  END SUBROUTINE refine_lcfs_radial_extrema
+
+  SUBROUTINE refine_radial_extremum(this, r, z, converged)
+    CLASS(equilibrium_geometry_t), INTENT(IN) :: this
+    REAL*8, INTENT(INOUT) :: r, z
+    LOGICAL, INTENT(OUT) :: converged
+    INTEGER :: iteration
+    REAL*8 :: psi, pr, pz, prr, pzz, prz, det, dr, dz
+
+    converged = .FALSE.
+    DO iteration = 1, newton_max_iterations
+       CALL this%evaluate_flux(r, z, psi, pr, pz, prr, pzz, prz)
+       det = pr*pzz - pz*prz
+       IF (ABS(det) <= geometry_tol) RETURN
+       dr = (-(psi - this%psi_lcfs)*pzz + pz*pz)/det
+       dz = (-pr*pz + prz*(psi - this%psi_lcfs))/det
+       r = MIN(MAX(r + dr, this%r(1)), this%r(this%nr))
+       z = MIN(MAX(z + dz, this%z(1)), this%z(this%nz))
+       IF (HYPOT(dr, dz) <= 1.d-11*MAX(1.d0, ABS(r))) THEN
+          converged = .TRUE.
+          RETURN
+       ENDIF
+    ENDDO
+  END SUBROUTINE refine_radial_extremum
+
+  LOGICAL FUNCTION point_in_polygon(r, z, polygon_r, polygon_z)
+    REAL*8, INTENT(IN) :: r, z, polygon_r(:), polygon_z(:)
+    INTEGER :: i, j, n
+    REAL*8 :: crossing_r
+
+    point_in_polygon = .FALSE.
+    n = SIZE(polygon_r)
+    j = n
+    DO i = 1, n
+       IF ((polygon_z(i) > z) .NEQV. (polygon_z(j) > z)) THEN
+          crossing_r = polygon_r(i) + (z - polygon_z(i))* &
+               (polygon_r(j) - polygon_r(i))/(polygon_z(j) - polygon_z(i))
+          IF (crossing_r > r) point_in_polygon = .NOT. point_in_polygon
+       ENDIF
+       j = i
+    ENDDO
+  END FUNCTION point_in_polygon
+
+END MODULE magnetic_topology

--- a/src/Models/magnetic_topology.f90
+++ b/src/Models/magnetic_topology.f90
@@ -161,7 +161,7 @@ CONTAINS
     CHARACTER(LEN=*), INTENT(OUT) :: message
     TYPE(critical_point_t) :: points(max_critical_points)
     INTEGER :: npoints, iaxis, ixpoint
-    REAL*8 :: psi_wall, x_seed_error, span_seed, outward_sign
+    REAL*8 :: psi_wall, span_seed, outward_sign
     REAL*8 :: wall_event_delta, x_event_delta, event_tolerance
     LOGICAL :: wall_found
 
@@ -203,7 +203,7 @@ CONTAINS
     ENDIF
 
     outward_sign = SIGN(1.d0, span_seed)
-    CALL select_lower_xpoint(this, points, npoints, span_seed, ixpoint, x_seed_error)
+    CALL select_lower_xpoint(this, points, npoints, span_seed, ixpoint)
     CALL find_wall_contact(this, wall_coordinates, wall_faces, wall_reference_nodes, &
          outward_sign, psi_wall, this%r_wall_contact, &
          this%z_wall_contact, wall_found)
@@ -443,19 +443,18 @@ CONTAINS
     ENDIF
   END SUBROUTINE select_axis
 
-  SUBROUTINE select_lower_xpoint(this, points, npoints, span_seed, ixpoint, score)
+  SUBROUTINE select_lower_xpoint(this, points, npoints, span_seed, ixpoint)
     CLASS(equilibrium_geometry_t), INTENT(IN) :: this
     TYPE(critical_point_t), INTENT(IN) :: points(max_critical_points)
     INTEGER, INTENT(IN) :: npoints
     REAL*8, INTENT(IN) :: span_seed
     INTEGER, INTENT(OUT) :: ixpoint
-    REAL*8, INTENT(OUT) :: score
     INTEGER :: i
-    REAL*8 :: candidate_score, theta, radius, distance, domain_scale
+    REAL*8 :: candidate_score, best_score, theta, radius, distance, domain_scale
     LOGICAL :: connected
 
     ixpoint = 0
-    score = HUGE(0.d0)
+    best_score = HUGE(0.d0)
     domain_scale = MAX(this%r(this%nr) - this%r(1), &
          this%z(this%nz) - this%z(1))
     DO i = 1, npoints
@@ -468,9 +467,9 @@ CONTAINS
        IF (.NOT. connected) CYCLE
        IF (ABS(radius - distance) > 1.d-5*domain_scale) CYCLE
        candidate_score = ABS((points(i)%psi - this%psi_sep_input)/span_seed)
-       IF (candidate_score < score) THEN
+       IF (candidate_score < best_score) THEN
           ixpoint = i
-          score = candidate_score
+          best_score = candidate_score
        ENDIF
     ENDDO
   END SUBROUTINE select_lower_xpoint
@@ -484,7 +483,7 @@ CONTAINS
     REAL*8, INTENT(OUT) :: psi_contact, r_contact, z_contact
     LOGICAL, INTENT(OUT) :: found
     INTEGER :: iface, isample, nsample
-    REAL*8 :: s0, s1, s2, f0, f1, f2, smin, fmin, r, z, psi, pr, pz
+    REAL*8 :: s0, s1, s2, f0, f1, f2, smin, r, z, psi
     REAL*8 :: best_delta, delta
 
     found = .FALSE.
@@ -510,7 +509,7 @@ CONTAINS
           CALL consider_wall_candidate(f2, r, z, psi)
           IF (f1 <= f0 .AND. f1 <= f2) THEN
              CALL minimize_wall_interval(this, wall_coordinates, wall_faces(iface, :), &
-                  wall_reference_nodes, outward_sign, s0, s2, smin, fmin)
+                  wall_reference_nodes, outward_sign, s0, s2, smin)
              CALL wall_flux(this, wall_coordinates, wall_faces(iface, :), &
                   wall_reference_nodes, smin, outward_sign, delta, r, z, psi)
              CALL consider_wall_candidate(delta, r, z, psi)
@@ -546,12 +545,12 @@ CONTAINS
   END SUBROUTINE find_wall_contact
 
   SUBROUTINE minimize_wall_interval(this, wall_coordinates, wall_face, &
-       wall_reference_nodes, outward_sign, sa, sb, smin, fmin)
+       wall_reference_nodes, outward_sign, sa, sb, smin)
     CLASS(equilibrium_geometry_t), INTENT(IN) :: this
     REAL*8, INTENT(IN) :: wall_coordinates(:, :), wall_reference_nodes(:)
     INTEGER, INTENT(IN) :: wall_face(:)
     REAL*8, INTENT(IN) :: outward_sign, sa, sb
-    REAL*8, INTENT(OUT) :: smin, fmin
+    REAL*8, INTENT(OUT) :: smin
     INTEGER :: iteration
     REAL*8, PARAMETER :: golden = 0.6180339887498948482d0
     REAL*8 :: left, right, s1, s2, f1, f2, r, z, psi
@@ -584,10 +583,8 @@ CONTAINS
     ENDDO
     IF (f1 <= f2) THEN
        smin = s1
-       fmin = f1
     ELSE
        smin = s2
-       fmin = f2
     ENDIF
   END SUBROUTINE minimize_wall_interval
 
@@ -598,47 +595,33 @@ CONTAINS
     INTEGER, INTENT(IN) :: wall_face(:)
     REAL*8, INTENT(IN) :: s, outward_sign
     REAL*8, INTENT(OUT) :: delta, r, z, psi
-    REAL*8 :: drds, dzds, pr, pz
+    REAL*8 :: pr, pz
 
     CALL evaluate_wall_position(wall_coordinates, wall_face, wall_reference_nodes, &
-         s, r, z, drds, dzds)
+         s, r, z)
     CALL this%evaluate_flux(r, z, psi, pr, pz)
     delta = outward_sign*(psi - this%psi_axis)
   END SUBROUTINE wall_flux
 
   SUBROUTINE evaluate_wall_position(wall_coordinates, wall_face, reference_nodes, &
-       s, r, z, drds, dzds)
+       s, r, z)
     REAL*8, INTENT(IN) :: wall_coordinates(:, :), reference_nodes(:), s
     INTEGER, INTENT(IN) :: wall_face(:)
-    REAL*8, INTENT(OUT) :: r, z, drds, dzds
-    INTEGER :: i, j, k, n
-    REAL*8 :: basis, derivative, product
+    REAL*8, INTENT(OUT) :: r, z
+    INTEGER :: i, j, n
+    REAL*8 :: basis
 
     n = SIZE(reference_nodes)
     r = 0.d0
     z = 0.d0
-    drds = 0.d0
-    dzds = 0.d0
     DO i = 1, n
        basis = 1.d0
        DO j = 1, n
           IF (j == i) CYCLE
           basis = basis*(s - reference_nodes(j))/(reference_nodes(i) - reference_nodes(j))
        ENDDO
-       derivative = 0.d0
-       DO k = 1, n
-          IF (k == i) CYCLE
-          product = 1.d0/(reference_nodes(i) - reference_nodes(k))
-          DO j = 1, n
-             IF (j == i .OR. j == k) CYCLE
-             product = product*(s - reference_nodes(j))/(reference_nodes(i) - reference_nodes(j))
-          ENDDO
-          derivative = derivative + product
-       ENDDO
        r = r + basis*wall_coordinates(wall_face(i), 1)
        z = z + basis*wall_coordinates(wall_face(i), 2)
-       drds = drds + derivative*wall_coordinates(wall_face(i), 1)
-       dzds = dzds + derivative*wall_coordinates(wall_face(i), 2)
     ENDDO
   END SUBROUTINE evaluate_wall_position
 
@@ -646,17 +629,17 @@ CONTAINS
     REAL*8, INTENT(IN) :: r, z, wall_coordinates(:, :), reference_nodes(:)
     INTEGER, INTENT(IN) :: wall_faces(:, :)
     INTEGER :: iface, isample, nsample
-    REAL*8 :: s, r0, z0, r1, z1, drds, dzds, intersection_r
+    REAL*8 :: s, r0, z0, r1, z1, intersection_r
 
     point_inside_wall = .FALSE.
     nsample = MAX(8, 3*SIZE(reference_nodes))
     DO iface = 1, SIZE(wall_faces, 1)
        CALL evaluate_wall_position(wall_coordinates, wall_faces(iface, :), &
-            reference_nodes, -1.d0, r0, z0, drds, dzds)
+            reference_nodes, -1.d0, r0, z0)
        DO isample = 1, nsample
           s = -1.d0 + 2.d0*REAL(isample)/REAL(nsample)
           CALL evaluate_wall_position(wall_coordinates, wall_faces(iface, :), &
-               reference_nodes, s, r1, z1, drds, dzds)
+               reference_nodes, s, r1, z1)
           IF ((z0 > z) .NEQV. (z1 > z)) THEN
              intersection_r = r0 + (z - z0)*(r1 - r0)/(z1 - z0)
              IF (intersection_r > r) point_inside_wall = .NOT. point_inside_wall

--- a/src/Models/magnetic_topology.f90
+++ b/src/Models/magnetic_topology.f90
@@ -53,6 +53,7 @@ MODULE magnetic_topology
      REAL*8 :: r_lcfs_min = 0.d0
      REAL*8 :: r_lcfs_max = 0.d0
      REAL*8 :: a_minor = 0.d0
+     LOGICAL :: lcfs_extrema_refined = .FALSE.
      REAL*8, ALLOCATABLE :: r(:)
      REAL*8, ALLOCATABLE :: z(:)
      REAL*8, ALLOCATABLE :: psi(:, :)
@@ -143,6 +144,7 @@ CONTAINS
     this%r_lcfs_min = 0.d0
     this%r_lcfs_max = 0.d0
     this%a_minor = 0.d0
+    this%lcfs_extrema_refined = .FALSE.
   END SUBROUTINE equilibrium_geometry_clear
 
   SUBROUTINE equilibrium_geometry_finalize(this)
@@ -782,6 +784,7 @@ CONTAINS
     CLASS(equilibrium_geometry_t), INTENT(INOUT) :: this
     INTEGER :: imin(1), imax(1)
     REAL*8 :: rmin, zmin, rmax, zmax
+    REAL*8 :: rmin_refined, zmin_refined, rmax_refined, zmax_refined
     LOGICAL :: okmin, okmax
 
     imin = MINLOC(this%lcfs_r)
@@ -790,10 +793,17 @@ CONTAINS
     zmin = this%lcfs_z(imin(1))
     rmax = this%lcfs_r(imax(1))
     zmax = this%lcfs_z(imax(1))
-    CALL refine_radial_extremum(this, rmin, zmin, okmin)
-    CALL refine_radial_extremum(this, rmax, zmax, okmax)
+    rmin_refined = rmin
+    zmin_refined = zmin
+    rmax_refined = rmax
+    zmax_refined = zmax
+    CALL refine_radial_extremum(this, rmin_refined, zmin_refined, okmin)
+    CALL refine_radial_extremum(this, rmax_refined, zmax_refined, okmax)
+    IF (okmin) rmin = rmin_refined
+    IF (okmax) rmax = rmax_refined
     this%r_lcfs_min = rmin
     this%r_lcfs_max = rmax
+    this%lcfs_extrema_refined = okmin .AND. okmax
   END SUBROUTINE refine_lcfs_radial_extrema
 
   SUBROUTINE refine_radial_extremum(this, r, z, converged)

--- a/src/Utils/Main_utils.f90
+++ b/src/Utils/Main_utils.f90
@@ -185,6 +185,7 @@ CONTAINS
 
     CALL transport_model_1d%set_config(rho_edge=transport_model_input%rho_edge, rho_core=transport_model_input%rho_core, &
          rho_diffusion_model_max=transport_model_input%rho_diffusion_model_max, c_bohm_i=transport_model_input%c_bohm_i, &
+         transport_region_policy=transport_model_input%transport_region_policy, &
          c_gyrobohm_i=transport_model_input%c_gyrobohm_i, c_bohm_e=transport_model_input%c_bohm_e, &
          c_gyrobohm_e=transport_model_input%c_gyrobohm_e, c_bohm_n=transport_model_input%c_bohm_n, &
          prandtl=transport_model_input%prandtl, pinch_model=transport_model_input%pinch_model, &
@@ -194,7 +195,7 @@ CONTAINS
          rho_blend_width=transport_model_input%rho_blend_width, diff_n_min_phys=transport_model_input%diff_n_min_phys, &
          diff_u_min_phys=transport_model_input%diff_u_min_phys, diff_e_min_phys=transport_model_input%diff_e_min_phys, &
          diff_ee_min_phys=transport_model_input%diff_ee_min_phys)
-    CALL fs_transport%build_profiles()
+    CALL fs_transport%build_profiles(transport_model_1d%config%transport_region_policy)
     CALL transport_model_1d%update_from_flux_surfaces(fs_transport)
   END SUBROUTINE update_reduced_transport_profiles
 

--- a/src/Utils/Main_utils.f90
+++ b/src/Utils/Main_utils.f90
@@ -188,6 +188,7 @@ CONTAINS
          transport_region_policy=transport_model_input%transport_region_policy, &
          c_gyrobohm_i=transport_model_input%c_gyrobohm_i, c_bohm_e=transport_model_input%c_bohm_e, &
          c_gyrobohm_e=transport_model_input%c_gyrobohm_e, c_bohm_n=transport_model_input%c_bohm_n, &
+         c_bohm_n_rho_slope=transport_model_input%c_bohm_n_rho_slope, &
          prandtl=transport_model_input%prandtl, pinch_model=transport_model_input%pinch_model, &
          c_pinch=transport_model_input%c_pinch, nu_th=transport_model_input%nu_th, &
          vpinch_const_phys=transport_model_input%vpinch_const_phys, rho_pinch_axis_width=transport_model_input%rho_pinch_axis_width, &

--- a/test/param_diffred.txt
+++ b/test/param_diffred.txt
@@ -74,9 +74,8 @@
     field_dimensions(2) = 1000                                   ! 2nd dimension dimensions of magnetic field file
     field_from_grid = .true.                                   ! true then reads from cartesian grid and then biineary interpolates on nodes
                                                                 ! false then reads from files with field on nodes
-    compute_from_flux   = .false.                                ! if the Br, Bz is computed from flux works not well, only with loading from nodes
-    divide_by_2pi       = .false.                               ! if corresponding to poloidal flux definition it is needed to divide by 2pi. For NICE .true.
-                                                                ! for FEEQS .false.
+    compute_from_flux   = .true.                                ! derive Br, Bz, and Jtor from psi using the fitted field convention
+    divide_by_2pi       = .false.                               ! fallback convention only when the field fit is unavailable
     jtor_path           = '/path/to/plasma/current'    ! Path to jtor h5 file. 
                                                                         ! If switch%ME = .true. then omit numbering part like 'Jtor/WEST_54487_Jtor'
                                                                         ! If switch%ME = .false. then put the full part 'Jtor/WEST_54487_Jtor_0000.h5'

--- a/test/param_initial.txt
+++ b/test/param_initial.txt
@@ -74,9 +74,8 @@
     field_dimensions(2) = 1000                                   ! 2nd dimension dimensions of magnetic field file
     field_from_grid = .true.                                   ! true then reads from cartesian grid and then biineary interpolates on nodes
                                                                 ! false then reads from files with field on nodes
-    compute_from_flux   = .false.                                ! if the Br, Bz is computed from flux works not well, only with loading from nodes
-    divide_by_2pi       = .false.                               ! if corresponding to poloidal flux definition it is needed to divide by 2pi. For NICE .true.
-                                                                ! for FEEQS .false.
+    compute_from_flux   = .true.                                ! derive Br, Bz, and Jtor from psi using the fitted field convention
+    divide_by_2pi       = .false.                               ! fallback convention only when the field fit is unavailable
     jtor_path           = '/path/to/plasma/current'    ! Path to jtor h5 file. 
                                                                         ! If switch%ME = .true. then omit numbering part like 'Jtor/WEST_54487_Jtor'
                                                                         ! If switch%ME = .false. then put the full part 'Jtor/WEST_54487_Jtor_0000.h5'

--- a/test/param_reference.txt
+++ b/test/param_reference.txt
@@ -74,9 +74,8 @@
     field_dimensions(2) = 2000                                   ! 2nd dimension dimensions of magnetic field file
     field_from_grid = .true.                                   ! true then reads from cartesian grid and then biineary interpolates on nodes
                                                                 ! false then reads from files with field on nodes
-    compute_from_flux   = .false.                                ! if the Br, Bz is computed from flux works not well, only with loading from nodes
-    divide_by_2pi       = .false.                               ! if corresponding to poloidal flux definition it is needed to divide by 2pi. For NICE .true.
-                                                                ! for FEEQS .false.
+    compute_from_flux   = .true.                                ! derive Br, Bz, and Jtor from psi using the fitted field convention
+    divide_by_2pi       = .false.                               ! fallback convention only when the field fit is unavailable
     jtor_path           = 'path/to/plasma/current.h5'    ! Path to jtor h5 file. 
                                                                         ! If switch%ME = .true. then omit numbering part like 'Jtor/WEST_54487_Jtor'
                                                                         ! If switch%ME = .false. then put the full part 'Jtor/WEST_54487_Jtor_0000.h5'

--- a/test/param_steady.txt
+++ b/test/param_steady.txt
@@ -74,9 +74,8 @@
     field_dimensions(2) = 1000                                   ! 2nd dimension dimensions of magnetic field file
     field_from_grid = .true.                                   ! true then reads from cartesian grid and then biineary interpolates on nodes
                                                                 ! false then reads from files with field on nodes
-    compute_from_flux   = .false.                                ! if the Br, Bz is computed from flux works not well, only with loading from nodes
-    divide_by_2pi       = .false.                               ! if corresponding to poloidal flux definition it is needed to divide by 2pi. For NICE .true.
-                                                                ! for FEEQS .false.
+    compute_from_flux   = .true.                                ! derive Br, Bz, and Jtor from psi using the fitted field convention
+    divide_by_2pi       = .false.                               ! fallback convention only when the field fit is unavailable
     jtor_path           = '/path/to/plasma/current'    ! Path to jtor h5 file. 
                                                                         ! If switch%ME = .true. then omit numbering part like 'Jtor/WEST_54487_Jtor'
                                                                         ! If switch%ME = .false. then put the full part 'Jtor/WEST_54487_Jtor_0000.h5'

--- a/test/transport_model.nml
+++ b/test/transport_model.nml
@@ -11,6 +11,12 @@
   ! rho_pol_norm >= rho_diffusion_model_max.
   rho_diffusion_model_max = 0.99
 
+  ! Topology regions in which reduced 1D transport is applied.
+  ! legacy_all_regions keeps the historical behavior.
+  ! core_and_main_sol excludes private flux while allowing rho_pol_norm > 1.
+  ! core_only restricts reduction, diffusion, and pinch to the confined core.
+  transport_region_policy = 'legacy_all_regions'
+
   ! Mixed Bohm / gyro-Bohm coefficients.
   ! Reference: JETTO/NTCC mixed Bohm / gyro-Bohm model description.
 
@@ -25,7 +31,7 @@
   ! 1 -> Militello collisionality-dependent pinch
   !      Reference: E. Militello-Asp et al., NF 2022-style suppression factor.
   ! 2 -> Polevoi-style geometric pinch baseline
-  !      with v_pinch = C * D * r / a^2.
+  !      with v_pinch = C * D * rho_pol_norm / a_minor.
   !      Reference for integrated-model usage: Polevoi et al., Nuclear Fusion (2020).
   ! 3 -> Constant pinch for steady-state checks.
   !      Positive values mean outward pinch (along increasing minor radius);

--- a/test/transport_model.nml
+++ b/test/transport_model.nml
@@ -25,6 +25,9 @@
   c_bohm_e = 8.e-5
   c_gyrobohm_e = 3.5e-2
   c_bohm_n = 1.0
+  ! Particle diffusivity factor: max(1-c_bohm_n_rho_slope*rho_pol_norm,0).
+  ! Set to zero for the topology-corrected untapered reference behavior.
+  c_bohm_n_rho_slope = 0.7
   prandtl = 1.0
 
   ! Pinch model selector.

--- a/unit_tests/README.md
+++ b/unit_tests/README.md
@@ -11,8 +11,13 @@ environment:
 source Make.inc/init_vars_libs.sh
 make check-magnetic-topology
 make check-magnetic-geometry
+make check-transport-region-policy
 ```
 
-The second target checks the signed poloidal-field fit, percent-level field
-perturbations, exact nodal/quadrature topology caches, and cache generation
-refresh.  Test executables are generated in `lib/` and removed by `make clean`.
+The topology target also checks that reversing the psi convention preserves the
+outward normalized-flux direction.  The second target checks the signed
+poloidal-field fit, percent-level field perturbations, exact nodal/quadrature
+topology caches, and cache generation refresh.  The region-policy target checks
+parsing, region inclusion, signed pinch orientation, null-normal suppression,
+and the explicit legacy magnetic-field fallback.  Test executables are generated
+in `lib/` and removed by `make clean`.

--- a/unit_tests/README.md
+++ b/unit_tests/README.md
@@ -12,6 +12,7 @@ source Make.inc/init_vars_libs.sh
 make check-magnetic-topology
 make check-magnetic-geometry
 make check-transport-region-policy
+make check-transport-taper
 ```
 
 The topology target also checks that reversing the psi convention preserves the
@@ -20,4 +21,5 @@ poloidal-field fit, percent-level field perturbations, exact nodal/quadrature
 topology caches, and cache generation refresh.  The region-policy target checks
 parsing, region inclusion, signed pinch orientation, null-normal suppression,
 and the explicit legacy magnetic-field fallback.  Test executables are generated
-in `lib/` and removed by `make clean`.
+in `lib/` and removed by `make clean`.  The taper target checks the disabled
+slope, the default `0.7` factor beyond the LCFS, and lower-bound clipping.

--- a/unit_tests/README.md
+++ b/unit_tests/README.md
@@ -10,6 +10,9 @@ environment:
 ```bash
 source Make.inc/init_vars_libs.sh
 make check-magnetic-topology
+make check-magnetic-geometry
 ```
 
-The test executable is generated in `lib/` and removed by `make clean`.
+The second target checks the signed poloidal-field fit, percent-level field
+perturbations, exact nodal/quadrature topology caches, and cache generation
+refresh.  Test executables are generated in `lib/` and removed by `make clean`.

--- a/unit_tests/README.md
+++ b/unit_tests/README.md
@@ -16,9 +16,12 @@ make check-transport-taper
 ```
 
 The topology target also checks that reversing the psi convention preserves the
-outward normalized-flux direction.  The second target checks the signed
-poloidal-field fit, percent-level field perturbations, exact nodal/quadrature
-topology caches, and cache generation refresh.  The region-policy target checks
+outward normalized-flux direction.  The second target checks all four supported
+poloidal-field conventions, noncanonical and percent-level field perturbations,
+the same-alpha Grad--Shafranov toroidal current and its fitted `+1`/`-1` sign
+convention, exact
+nodal/quadrature topology caches, and cache generation refresh.  The
+region-policy target checks
 parsing, region inclusion, signed pinch orientation, null-normal suppression,
 and the explicit legacy magnetic-field fallback.  Test executables are generated
 in `lib/` and removed by `make clean`.  The taper target checks the disabled

--- a/unit_tests/README.md
+++ b/unit_tests/README.md
@@ -1,0 +1,15 @@
+# Focused unit tests
+
+This directory contains small deterministic checks for numerical machinery that
+can be exercised without launching a full MHDG case.  Production-equilibrium
+and end-to-end coverage remains in `regression_tests`.
+
+Run the magnetic-topology checks from `lib/` after loading the build
+environment:
+
+```bash
+source Make.inc/init_vars_libs.sh
+make check-magnetic-topology
+```
+
+The test executable is generated in `lib/` and removed by `make clean`.

--- a/unit_tests/fortran/test_magnetic_geometry_state.f90
+++ b/unit_tests/fortran/test_magnetic_geometry_state.f90
@@ -1,0 +1,151 @@
+PROGRAM test_magnetic_geometry_state
+  USE magnetic_topology
+  USE magnetic_geometry_state
+  IMPLICIT NONE
+
+  CALL test_signed_field_fit()
+  CALL test_exact_cache_and_refresh()
+  WRITE (*, '(A)') 'magnetic geometry state checks: PASS'
+
+CONTAINS
+
+  SUBROUTINE test_signed_field_fit()
+    TYPE(equilibrium_geometry_t) :: geometry
+    TYPE(poloidal_field_fit_t) :: fit
+    INTEGER, PARAMETER :: nr = 31, nz = 29
+    REAL*8, PARAMETER :: r0 = 2.d0, alpha = -1.d0/(2.d0*ACOS(-1.d0))
+    REAL*8 :: r(nr), z(nz), psi(nz, nr), br(nz, nr), bz(nz, nr)
+    REAL*8 :: psi_value, psi_r, psi_z, perturbation
+    INTEGER :: ir, iz, ierr
+    CHARACTER(LEN=256) :: message
+
+    CALL fill_circular_flux(r0, r, z, psi)
+    CALL geometry%init(r, z, psi, ierr, message)
+    CALL assert_ok(ierr, message)
+    DO ir = 1, nr
+       DO iz = 1, nz
+          CALL geometry%evaluate_flux(r(ir), z(iz), psi_value, psi_r, psi_z)
+          br(iz, ir) = alpha*(-psi_z/r(ir))
+          bz(iz, ir) = alpha*( psi_r/r(ir))
+       ENDDO
+    ENDDO
+
+    CALL fit_poloidal_field_scale(geometry, r, z, br, bz, 1.d0, fit)
+    CALL assert_true(fit%is_valid, 'signed 1/(2pi) field fit is invalid')
+    CALL assert_close(fit%alpha, alpha, 2.d-13, 'signed 1/(2pi) fit')
+    CALL assert_close(fit%relative_rms, 0.d0, 2.d-13, 'exact field-fit residual')
+
+    DO ir = 1, nr
+       DO iz = 1, nz
+          perturbation = 0.01d0*SIN(0.7d0*REAL(ir) + 0.3d0*REAL(iz))
+          br(iz, ir) = br(iz, ir)*(1.d0 + perturbation)
+          bz(iz, ir) = bz(iz, ir)*(1.d0 - perturbation)
+       ENDDO
+    ENDDO
+    CALL fit_poloidal_field_scale(geometry, r, z, br, bz, 1.d0, fit)
+    CALL assert_true(fit%is_valid, 'percent-perturbed field fit is invalid')
+    CALL assert_close(fit%alpha, alpha, 2.d-4, 'percent-perturbed fit scale')
+    CALL assert_true(fit%relative_rms > 1.d-3 .AND. fit%relative_rms < 0.02d0, &
+         'percent-perturbed field residual')
+  END SUBROUTINE test_signed_field_fit
+
+  SUBROUTINE test_exact_cache_and_refresh()
+    TYPE(equilibrium_geometry_t) :: geometry
+    TYPE(magnetic_geometry_cache_t) :: cache
+    INTEGER, PARAMETER :: nr = 41, nz = 41
+    REAL*8, PARAMETER :: r0 = 2.d0, a = 0.5d0
+    REAL*8 :: r(nr), z(nz), psi(nz, nr), wall(4, 2), wall_ref(2)
+    REAL*8 :: nodes(4, 2), volume_shape(1, 4), face_shape(1, 2)
+    INTEGER :: wall_faces(4, 2), elements(1, 4), face_nodes(4, 2)
+    INTEGER :: ierr, generation
+    CHARACTER(LEN=256) :: message
+
+    CALL fill_circular_flux(r0, r, z, psi)
+    wall(1, :) = (/r0 - a, -0.7d0/)
+    wall(2, :) = (/r0 + 0.7d0, -0.7d0/)
+    wall(3, :) = (/r0 + 0.7d0,  0.7d0/)
+    wall(4, :) = (/r0 - a,  0.7d0/)
+    wall_faces = RESHAPE((/1, 2, 2, 3, 3, 4, 4, 1/), SHAPE(wall_faces), ORDER=(/2, 1/))
+    wall_ref = (/-1.d0, 1.d0/)
+    CALL geometry%init(r, z, psi, ierr, message)
+    CALL assert_ok(ierr, message)
+    CALL geometry%analyze(1.02d0*a*a, wall, wall_faces, wall_ref, ierr, message)
+    CALL assert_ok(ierr, message)
+
+    nodes(1, :) = (/r0 - 0.25d0, -0.25d0/)
+    nodes(2, :) = (/r0 + 0.25d0, -0.25d0/)
+    nodes(3, :) = (/r0 + 0.25d0,  0.25d0/)
+    nodes(4, :) = (/r0 - 0.25d0,  0.25d0/)
+    elements(1, :) = (/1, 2, 3, 4/)
+    face_nodes(1, :) = (/1, 2/)
+    face_nodes(2, :) = (/2, 3/)
+    face_nodes(3, :) = (/3, 4/)
+    face_nodes(4, :) = (/4, 1/)
+    volume_shape(1, :) = 0.25d0
+    face_shape(1, :) = 0.5d0
+
+    CALL cache%build(geometry, nodes, elements, volume_shape, face_nodes, face_shape)
+    CALL assert_true(cache%is_initialized, 'geometry cache was not initialized')
+    CALL assert_close(cache%nodal_rho(1), SQRT(0.5d0), 2.d-5, &
+         'exact nodal rho')
+    CALL assert_close(cache%volume_rho(1, 1), 0.d0, 2.d-8, &
+         'exact volume-quadrature rho')
+    CALL assert_close(cache%face_rho(1, 1, 1), 0.5d0, 2.d-5, &
+         'exact face-quadrature rho')
+    CALL assert_true(ALL(cache%nodal_region == magnetic_region_core), &
+         'nodal topology regions')
+    generation = cache%generation
+    CALL cache%build(geometry, nodes, elements, volume_shape, face_nodes, face_shape)
+    CALL assert_true(cache%generation == generation + 1, &
+         'cache generation did not advance on refresh')
+    CALL assert_true(cache%equilibrium_generation == geometry%generation, &
+         'cache/equilibrium generation mismatch')
+  END SUBROUTINE test_exact_cache_and_refresh
+
+  SUBROUTINE fill_circular_flux(r0, r, z, psi)
+    REAL*8, INTENT(IN) :: r0
+    REAL*8, INTENT(OUT) :: r(:), z(:), psi(:, :)
+    INTEGER :: ir, iz
+
+    DO ir = 1, SIZE(r)
+       r(ir) = r0 - 0.8d0 + 1.6d0*REAL(ir - 1)/REAL(SIZE(r) - 1)
+    ENDDO
+    DO iz = 1, SIZE(z)
+       z(iz) = -0.8d0 + 1.6d0*REAL(iz - 1)/REAL(SIZE(z) - 1)
+    ENDDO
+    DO ir = 1, SIZE(r)
+       DO iz = 1, SIZE(z)
+          psi(iz, ir) = (r(ir) - r0)**2 + z(iz)**2
+       ENDDO
+    ENDDO
+  END SUBROUTINE fill_circular_flux
+
+  SUBROUTINE assert_ok(ierr, message)
+    INTEGER, INTENT(IN) :: ierr
+    CHARACTER(LEN=*), INTENT(IN) :: message
+    IF (ierr /= 0) THEN
+       WRITE (*, '(A,I0,2A)') 'FAIL(', ierr, '): ', TRIM(message)
+       ERROR STOP 1
+    ENDIF
+  END SUBROUTINE assert_ok
+
+  SUBROUTINE assert_close(value, expected, tolerance, label)
+    REAL*8, INTENT(IN) :: value, expected, tolerance
+    CHARACTER(LEN=*), INTENT(IN) :: label
+    IF (ABS(value - expected) > tolerance) THEN
+       WRITE (*, '(3A,3ES16.7)') 'FAIL: ', TRIM(label), ': ', &
+            value, expected, tolerance
+       ERROR STOP 1
+    ENDIF
+  END SUBROUTINE assert_close
+
+  SUBROUTINE assert_true(condition, label)
+    LOGICAL, INTENT(IN) :: condition
+    CHARACTER(LEN=*), INTENT(IN) :: label
+    IF (.NOT. condition) THEN
+       WRITE (*, '(2A)') 'FAIL: ', TRIM(label)
+       ERROR STOP 1
+    ENDIF
+  END SUBROUTINE assert_true
+
+END PROGRAM test_magnetic_geometry_state

--- a/unit_tests/fortran/test_magnetic_geometry_state.f90
+++ b/unit_tests/fortran/test_magnetic_geometry_state.f90
@@ -3,38 +3,54 @@ PROGRAM test_magnetic_geometry_state
   USE magnetic_geometry_state
   IMPLICIT NONE
 
-  CALL test_signed_field_fit()
+  CALL test_canonical_field_fit()
+  CALL test_flux_derived_toroidal_current()
+  CALL test_toroidal_current_sign_fit()
   CALL test_exact_cache_and_refresh()
   WRITE (*, '(A)') 'magnetic geometry state checks: PASS'
 
 CONTAINS
 
-  SUBROUTINE test_signed_field_fit()
+  SUBROUTINE test_canonical_field_fit()
     TYPE(equilibrium_geometry_t) :: geometry
     TYPE(poloidal_field_fit_t) :: fit
     INTEGER, PARAMETER :: nr = 31, nz = 29
-    REAL*8, PARAMETER :: r0 = 2.d0, alpha = -1.d0/(2.d0*ACOS(-1.d0))
+    REAL*8, PARAMETER :: r0 = 2.d0
+    REAL*8 :: canonical_alpha(4)
     REAL*8 :: r(nr), z(nz), psi(nz, nr), br(nz, nr), bz(nz, nr)
     REAL*8 :: psi_value, psi_r, psi_z, perturbation
-    INTEGER :: ir, iz, ierr
+    INTEGER :: ir, iz, ierr, icandidate
     CHARACTER(LEN=256) :: message
 
     CALL fill_circular_flux(r0, r, z, psi)
     CALL geometry%init(r, z, psi, ierr, message)
     CALL assert_ok(ierr, message)
-    DO ir = 1, nr
-       DO iz = 1, nz
-          CALL geometry%evaluate_flux(r(ir), z(iz), psi_value, psi_r, psi_z)
-          br(iz, ir) = alpha*(-psi_z/r(ir))
-          bz(iz, ir) = alpha*( psi_r/r(ir))
-       ENDDO
+    canonical_alpha = (/1.d0, -1.d0, 1.d0/(2.d0*ACOS(-1.d0)), &
+         -1.d0/(2.d0*ACOS(-1.d0))/)
+    DO icandidate = 1, SIZE(canonical_alpha)
+       CALL fill_poloidal_field(geometry, r, z, canonical_alpha(icandidate), br, bz)
+       CALL fit_poloidal_field_scale(geometry, r, z, br, bz, 1.d0, fit)
+       CALL assert_true(fit%is_valid, 'canonical field fit is invalid')
+       CALL assert_close(fit%alpha, canonical_alpha(icandidate), 2.d-13, &
+            'unconstrained canonical alpha')
+       CALL assert_close(fit%applied_alpha, canonical_alpha(icandidate), 2.d-13, &
+            'applied canonical alpha')
+       CALL assert_true(fit%convention_id == icandidate, 'canonical convention ID')
+       CALL assert_close(fit%applied_relative_rms, 0.d0, 2.d-13, &
+            'exact applied field residual')
     ENDDO
 
+    CALL fill_poloidal_field(geometry, r, z, 0.8d0, br, bz)
     CALL fit_poloidal_field_scale(geometry, r, z, br, bz, 1.d0, fit)
-    CALL assert_true(fit%is_valid, 'signed 1/(2pi) field fit is invalid')
-    CALL assert_close(fit%alpha, alpha, 2.d-13, 'signed 1/(2pi) fit')
-    CALL assert_close(fit%relative_rms, 0.d0, 2.d-13, 'exact field-fit residual')
+    CALL assert_close(fit%alpha, 0.8d0, 2.d-13, 'noncanonical field fit')
+    CALL assert_close(fit%applied_alpha, 1.d0, 2.d-13, &
+         'nearest canonical field convention')
+    CALL assert_close(fit%canonical_relative_difference, 0.2d0, 2.d-13, &
+         'noncanonical alpha distance')
+    CALL assert_close(fit%applied_relative_rms, 0.25d0, 2.d-13, &
+         'noncanonical applied residual')
 
+    CALL fill_poloidal_field(geometry, r, z, canonical_alpha(4), br, bz)
     DO ir = 1, nr
        DO iz = 1, nz
           perturbation = 0.01d0*SIN(0.7d0*REAL(ir) + 0.3d0*REAL(iz))
@@ -44,10 +60,82 @@ CONTAINS
     ENDDO
     CALL fit_poloidal_field_scale(geometry, r, z, br, bz, 1.d0, fit)
     CALL assert_true(fit%is_valid, 'percent-perturbed field fit is invalid')
-    CALL assert_close(fit%alpha, alpha, 2.d-4, 'percent-perturbed fit scale')
+    CALL assert_close(fit%alpha, canonical_alpha(4), 2.d-4, &
+         'percent-perturbed fit scale')
+    CALL assert_close(fit%applied_alpha, canonical_alpha(4), 2.d-13, &
+         'percent-perturbed applied alpha')
     CALL assert_true(fit%relative_rms > 1.d-3 .AND. fit%relative_rms < 0.02d0, &
          'percent-perturbed field residual')
-  END SUBROUTINE test_signed_field_fit
+  END SUBROUTINE test_canonical_field_fit
+
+  SUBROUTINE test_flux_derived_toroidal_current()
+    TYPE(equilibrium_geometry_t) :: geometry
+    INTEGER, PARAMETER :: nr = 31, nz = 29
+    REAL*8, PARAMETER :: r0 = 2.d0, r_eval = 2.2d0, z_eval = 0.1d0
+    REAL*8, PARAMETER :: length_scale = 2.d0
+    REAL*8 :: r(nr), z(nz), psi(nz, nr), jtor, expected, alpha
+    REAL*8 :: mu0, grad_shafranov_psi
+    INTEGER :: ierr
+    LOGICAL :: is_valid
+    CHARACTER(LEN=256) :: message
+
+    CALL fill_circular_flux(r0, r, z, psi)
+    CALL geometry%init(r, z, psi, ierr, message)
+    CALL assert_ok(ierr, message)
+    alpha = 1.d0/(2.d0*ACOS(-1.d0))
+    mu0 = 4.d-7*ACOS(-1.d0)
+    grad_shafranov_psi = 4.d0 - 2.d0*(r_eval - r0)/r_eval
+    expected = -alpha*grad_shafranov_psi/ &
+         (mu0*r_eval*length_scale**3)
+
+    CALL evaluate_flux_derived_toroidal_current(geometry, r_eval, z_eval, &
+         length_scale, alpha, jtor, is_valid)
+    CALL assert_true(is_valid, 'flux-derived toroidal current is invalid')
+    CALL assert_close(jtor, expected, 2.d-10*ABS(expected), &
+         'flux-derived toroidal current')
+
+    CALL evaluate_flux_derived_toroidal_current(geometry, r_eval, z_eval, &
+         length_scale, -alpha, jtor, is_valid)
+    CALL assert_close(jtor, -expected, 2.d-10*ABS(expected), &
+         'reversed-alpha toroidal current')
+  END SUBROUTINE test_flux_derived_toroidal_current
+
+  SUBROUTINE test_toroidal_current_sign_fit()
+    TYPE(toroidal_current_comparison_t) :: fit
+
+    CALL fit_toroidal_current_sign(4.d0, 4.d0, -4.d0, fit)
+    CALL assert_true(fit%is_valid, 'negative Jtor sign fit is invalid')
+    CALL assert_true(fit%applied_sign == -1, 'negative Jtor sign selection')
+    CALL assert_close(fit%core_raw_relative_l2, 2.d0, 1.d-14, &
+         'raw negative-sign Jtor residual')
+    CALL assert_close(fit%core_relative_l2, 0.d0, 1.d-14, &
+         'applied negative-sign Jtor residual')
+    CALL assert_close(fit%core_best_scale, 1.d0, 1.d-14, &
+         'applied negative-sign Jtor scale')
+
+    CALL fit_toroidal_current_sign(9.d0, 4.d0, 6.d0, fit)
+    CALL assert_true(fit%applied_sign == 1, 'positive Jtor sign selection')
+    CALL assert_close(fit%core_norm_ratio, 1.5d0, 1.d-14, &
+         'positive-sign Jtor norm ratio')
+    CALL assert_close(fit%core_best_scale, 2.d0/3.d0, 1.d-14, &
+         'positive-sign Jtor scale')
+  END SUBROUTINE test_toroidal_current_sign_fit
+
+  SUBROUTINE fill_poloidal_field(geometry, r, z, alpha, br, bz)
+    TYPE(equilibrium_geometry_t), INTENT(IN) :: geometry
+    REAL*8, INTENT(IN) :: r(:), z(:), alpha
+    REAL*8, INTENT(OUT) :: br(:, :), bz(:, :)
+    REAL*8 :: psi_value, psi_r, psi_z
+    INTEGER :: ir, iz
+
+    DO ir = 1, SIZE(r)
+       DO iz = 1, SIZE(z)
+          CALL geometry%evaluate_flux(r(ir), z(iz), psi_value, psi_r, psi_z)
+          br(iz, ir) = -alpha*psi_z/r(ir)
+          bz(iz, ir) =  alpha*psi_r/r(ir)
+       ENDDO
+    ENDDO
+  END SUBROUTINE fill_poloidal_field
 
   SUBROUTINE test_exact_cache_and_refresh()
     TYPE(equilibrium_geometry_t) :: geometry

--- a/unit_tests/fortran/test_magnetic_topology.f90
+++ b/unit_tests/fortran/test_magnetic_topology.f90
@@ -1,0 +1,258 @@
+PROGRAM test_magnetic_topology
+  USE magnetic_topology
+  IMPLICIT NONE
+
+  CALL test_limited_wall_contact()
+  CALL test_limited_sharp_corner_contact()
+  CALL test_high_order_wall_and_grid_resolution()
+  CALL test_lower_single_null_regions()
+  WRITE (*, '(A)') 'magnetic topology analytical checks: PASS'
+
+CONTAINS
+
+  SUBROUTINE test_limited_wall_contact()
+    TYPE(equilibrium_geometry_t) :: geometry
+    INTEGER, PARAMETER :: nr = 81, nz = 81
+    REAL*8, PARAMETER :: r0 = 2.d0, a = 0.5d0
+    REAL*8 :: r(nr), z(nz), psi(nz, nr)
+    REAL*8 :: wall(4, 2), ref_nodes(2)
+    INTEGER :: faces(4, 2), ierr, ir, iz, region
+    REAL*8 :: psi_n, rho, normal(2)
+    CHARACTER(LEN=256) :: message
+
+    DO ir = 1, nr
+       r(ir) = r0 - 0.75d0 + 1.5d0*REAL(ir - 1)/REAL(nr - 1)
+    ENDDO
+    DO iz = 1, nz
+       z(iz) = -0.75d0 + 1.5d0*REAL(iz - 1)/REAL(nz - 1)
+    ENDDO
+    DO iz = 1, nz
+       DO ir = 1, nr
+          psi(iz, ir) = (r(ir) - r0)**2 + z(iz)**2
+       ENDDO
+    ENDDO
+
+    wall(1, :) = (/r0 - a, -0.6d0/)
+    wall(2, :) = (/r0 + 0.65d0, -0.6d0/)
+    wall(3, :) = (/r0 + 0.65d0, 0.6d0/)
+    wall(4, :) = (/r0 - a, 0.6d0/)
+    faces(1, :) = (/1, 2/)
+    faces(2, :) = (/2, 3/)
+    faces(3, :) = (/3, 4/)
+    faces(4, :) = (/4, 1/)
+    ref_nodes = (/-1.d0, 1.d0/)
+
+    CALL geometry%init(r, z, psi, ierr, message)
+    CALL assert_ok(ierr, message)
+    CALL geometry%analyze(1.03d0*a*a, wall, faces, ref_nodes, ierr, message)
+    CALL assert_ok(ierr, message)
+    CALL assert_true(geometry%topology_kind == topology_limited, &
+         'circular wall-contact case was not classified as limited')
+    CALL assert_close(geometry%r_axis, r0, 2.d-6, 'limited magnetic-axis R')
+    CALL assert_close(geometry%z_axis, 0.d0, 2.d-6, 'limited magnetic-axis Z')
+    CALL assert_close(geometry%psi_lcfs, a*a, 2.d-6, 'wall-derived LCFS flux')
+    CALL assert_close(geometry%a_minor, a, 2.d-5, 'wall-derived minor radius')
+
+    CALL geometry%evaluate_topology(r0 + 0.25d0, 0.d0, psi_n, rho, normal, region)
+    CALL assert_true(region == magnetic_region_core, 'limited core classification')
+    CALL assert_close(rho, 0.5d0, 2.d-5, 'limited normalized poloidal radius')
+    CALL assert_true(normal(1) > 0.999d0, 'limited outward normal')
+    CALL geometry%evaluate_topology(r0 + 0.6d0, 0.d0, psi_n, rho, normal, region)
+    CALL assert_true(region == magnetic_region_main_sol, 'limited SOL classification')
+  END SUBROUTINE test_limited_wall_contact
+
+  SUBROUTINE test_limited_sharp_corner_contact()
+    TYPE(equilibrium_geometry_t) :: geometry
+    INTEGER, PARAMETER :: nr = 41, nz = 41
+    REAL*8, PARAMETER :: r0 = 2.d0, a = 0.5d0
+    REAL*8 :: r(nr), z(nz), psi(nz, nr), wall(7, 2), ref_nodes(2)
+    INTEGER :: faces(7, 2), ierr, ir, iz
+    CHARACTER(LEN=256) :: message
+
+    CALL fill_circular_flux(r0, nr, nz, r, z, psi)
+    wall(1, :) = (/r0 - 0.8d0, -0.7d0/)
+    wall(2, :) = (/r0 + 0.8d0, -0.7d0/)
+    wall(3, :) = (/r0 + 0.8d0,  0.7d0/)
+    wall(4, :) = (/r0 - 0.8d0,  0.7d0/)
+    wall(5, :) = (/r0 - 0.8d0,  0.2d0/)
+    wall(6, :) = (/r0 - a,       0.d0/)
+    wall(7, :) = (/r0 - 0.8d0, -0.2d0/)
+    DO ir = 1, 6
+       faces(ir, :) = (/ir, ir + 1/)
+    ENDDO
+    faces(7, :) = (/7, 1/)
+    ref_nodes = (/-1.d0, 1.d0/)
+
+    CALL geometry%init(r, z, psi, ierr, message)
+    CALL assert_ok(ierr, message)
+    CALL geometry%analyze(0.96d0*a*a, wall, faces, ref_nodes, ierr, message)
+    CALL assert_ok(ierr, message)
+    CALL assert_true(geometry%topology_kind == topology_limited, &
+         'sharp-corner limiter was not classified as limited')
+    CALL assert_close(geometry%psi_lcfs, a*a, 2.d-6, &
+         'sharp-corner wall-derived LCFS flux')
+    CALL assert_close(geometry%r_wall_contact, r0 - a, 2.d-6, &
+         'sharp-corner contact R')
+    CALL assert_close(geometry%z_wall_contact, 0.d0, 2.d-6, &
+         'sharp-corner contact Z')
+  END SUBROUTINE test_limited_sharp_corner_contact
+
+  SUBROUTINE test_high_order_wall_and_grid_resolution()
+    TYPE(equilibrium_geometry_t) :: coarse, fine
+    INTEGER, PARAMETER :: nr_coarse = 17, nz_coarse = 19
+    INTEGER, PARAMETER :: nr_fine = 83, nz_fine = 79
+    REAL*8, PARAMETER :: r0 = 2.d0, a = 0.5d0
+    REAL*8 :: rc(nr_coarse), zc(nz_coarse), psic(nz_coarse, nr_coarse)
+    REAL*8 :: rf(nr_fine), zf(nz_fine), psif(nz_fine, nr_fine)
+    REAL*8 :: wall(8, 2), ref_nodes(3)
+    INTEGER :: faces(4, 3), ierr
+    CHARACTER(LEN=256) :: message
+
+    CALL fill_circular_flux(r0, nr_coarse, nz_coarse, rc, zc, psic)
+    CALL fill_circular_flux(r0, nr_fine, nz_fine, rf, zf, psif)
+
+    wall(1, :) = (/r0 - a - 0.2d0, -0.6d0/)
+    wall(2, :) = (/r0 + 0.7d0,      -0.6d0/)
+    wall(3, :) = (/r0 + 0.7d0,       0.6d0/)
+    wall(4, :) = (/r0 - a - 0.2d0,  0.6d0/)
+    wall(5, :) = (/r0 + 0.1d0,      -0.6d0/)
+    wall(6, :) = (/r0 + 0.7d0,       0.d0/)
+    wall(7, :) = (/r0 + 0.1d0,       0.6d0/)
+    wall(8, :) = (/r0 - a,            0.d0/)
+    faces(1, :) = (/1, 5, 2/)
+    faces(2, :) = (/2, 6, 3/)
+    faces(3, :) = (/3, 7, 4/)
+    faces(4, :) = (/4, 8, 1/)
+    ref_nodes = (/-1.d0, 0.d0, 1.d0/)
+
+    CALL coarse%init(rc, zc, psic, ierr, message)
+    CALL assert_ok(ierr, message)
+    CALL coarse%analyze(1.04d0*a*a, wall, faces, ref_nodes, ierr, message)
+    CALL assert_ok(ierr, message)
+    CALL fine%init(rf, zf, psif, ierr, message)
+    CALL assert_ok(ierr, message)
+    CALL fine%analyze(0.97d0*a*a, wall, faces, ref_nodes, ierr, message)
+    CALL assert_ok(ierr, message)
+
+    CALL assert_close(coarse%psi_lcfs, a*a, 3.d-6, &
+         'quadratic-wall coarse-grid LCFS flux')
+    CALL assert_close(fine%psi_lcfs, a*a, 3.d-6, &
+         'quadratic-wall fine-grid LCFS flux')
+    CALL assert_close(coarse%psi_lcfs, fine%psi_lcfs, 2.d-7, &
+         'coarse/fine equilibrium LCFS consistency')
+    CALL assert_close(coarse%r_wall_contact, r0 - a, 3.d-6, &
+         'quadratic high-order wall contact R')
+    CALL assert_close(coarse%z_wall_contact, 0.d0, 3.d-6, &
+         'quadratic high-order wall contact Z')
+  END SUBROUTINE test_high_order_wall_and_grid_resolution
+
+  SUBROUTINE test_lower_single_null_regions()
+    TYPE(equilibrium_geometry_t) :: geometry
+    INTEGER, PARAMETER :: nr = 81, nz = 121
+    REAL*8, PARAMETER :: r0 = 2.d0, b = 0.6d0, k = 1.d0
+    REAL*8, PARAMETER :: psi_x = k*b**3/6.d0
+    REAL*8 :: r(nr), z(nz), psi(nz, nr)
+    REAL*8 :: wall(4, 2), ref_nodes(2)
+    INTEGER :: faces(4, 2), ierr, ir, iz, region
+    REAL*8 :: psi_n, rho, normal(2), psi_n_core, rho_core, target_psi
+    CHARACTER(LEN=256) :: message
+
+    DO ir = 1, nr
+       r(ir) = 1.2d0 + 1.6d0*REAL(ir - 1)/REAL(nr - 1)
+    ENDDO
+    DO iz = 1, nz
+       z(iz) = -1.2d0 + 2.4d0*REAL(iz - 1)/REAL(nz - 1)
+    ENDDO
+    DO iz = 1, nz
+       DO ir = 1, nr
+          psi(iz, ir) = (r(ir) - r0)**2 + &
+               k*(z(iz)**3/3.d0 + b*z(iz)**2/2.d0)
+       ENDDO
+    ENDDO
+
+    wall(1, :) = (/1.35d0, -1.d0/)
+    wall(2, :) = (/2.65d0, -1.d0/)
+    wall(3, :) = (/2.65d0, 0.9d0/)
+    wall(4, :) = (/1.35d0, 0.9d0/)
+    faces(1, :) = (/1, 2/)
+    faces(2, :) = (/2, 3/)
+    faces(3, :) = (/3, 4/)
+    faces(4, :) = (/4, 1/)
+    ref_nodes = (/-1.d0, 1.d0/)
+
+    CALL geometry%init(r, z, psi, ierr, message)
+    CALL assert_ok(ierr, message)
+    CALL geometry%analyze(1.20d0*psi_x, wall, faces, ref_nodes, ierr, message)
+    CALL assert_ok(ierr, message)
+    CALL assert_true(geometry%topology_kind == topology_lower_single_null, &
+         'polynomial diverted case was not classified as lower single null')
+    CALL assert_close(geometry%r_axis, r0, 2.d-3, 'diverted magnetic-axis R')
+    CALL assert_close(geometry%z_axis, 0.d0, 2.d-3, 'diverted magnetic-axis Z')
+    CALL assert_close(geometry%r_xpoint, r0, 2.d-3, 'lower X-point R')
+    CALL assert_close(geometry%z_xpoint, -b, 2.d-3, 'lower X-point Z')
+    CALL assert_close(geometry%psi_lcfs, psi_x, 4.d-4, 'X-point LCFS flux')
+    CALL assert_close(geometry%a_minor, SQRT(psi_x), 2.d-3, &
+         'diverted LCFS half width')
+
+    CALL geometry%evaluate_topology(r0, 0.15d0, psi_n, rho, normal, region)
+    CALL assert_true(region == magnetic_region_core, 'diverted core classification')
+    target_psi = k*(0.2d0**3/3.d0 + b*0.2d0**2/2.d0)
+    CALL geometry%evaluate_topology(r0, 0.2d0, psi_n_core, rho_core, normal, region)
+    CALL assert_true(region == magnetic_region_core, 'equal-rho core classification')
+    CALL geometry%evaluate_topology(r0 + SQRT(target_psi), -0.9d0, psi_n, rho, normal, region)
+    CALL assert_true(psi_n < 1.d0, 'private-flux fixture must have psi_n below one')
+    CALL assert_close(rho, rho_core, 2.d-3, 'equal-rho core/PFR values')
+    CALL assert_true(region == magnetic_region_private_flux, &
+         'disconnected private-flux classification')
+    CALL geometry%evaluate_topology(r0 + 0.5d0, 0.d0, psi_n, rho, normal, region)
+    CALL assert_true(psi_n > 1.d0, 'main-SOL fixture must have rho above one')
+    CALL assert_true(region == magnetic_region_main_sol, 'main-SOL classification')
+  END SUBROUTINE test_lower_single_null_regions
+
+  SUBROUTINE fill_circular_flux(r0, nr, nz, r, z, psi)
+    REAL*8, INTENT(IN) :: r0
+    INTEGER, INTENT(IN) :: nr, nz
+    REAL*8, INTENT(OUT) :: r(nr), z(nz), psi(nz, nr)
+    INTEGER :: ir, iz
+
+    DO ir = 1, nr
+       r(ir) = r0 - 0.9d0 + 1.8d0*REAL(ir - 1)/REAL(nr - 1)
+    ENDDO
+    DO iz = 1, nz
+       z(iz) = -0.8d0 + 1.6d0*REAL(iz - 1)/REAL(nz - 1)
+    ENDDO
+    DO iz = 1, nz
+       DO ir = 1, nr
+          psi(iz, ir) = (r(ir) - r0)**2 + z(iz)**2
+       ENDDO
+    ENDDO
+  END SUBROUTINE fill_circular_flux
+
+  SUBROUTINE assert_ok(ierr, message)
+    INTEGER, INTENT(IN) :: ierr
+    CHARACTER(LEN=*), INTENT(IN) :: message
+    IF (ierr /= 0) THEN
+       WRITE (*, '(A,I0,2A)') 'FAIL(', ierr, '): ', TRIM(message)
+       ERROR STOP 1
+    ENDIF
+  END SUBROUTINE assert_ok
+
+  SUBROUTINE assert_close(value, expected, tolerance, label)
+    REAL*8, INTENT(IN) :: value, expected, tolerance
+    CHARACTER(LEN=*), INTENT(IN) :: label
+    IF (ABS(value - expected) > tolerance) THEN
+       WRITE (*, '(3A,3ES16.7)') 'FAIL: ', TRIM(label), ': ', value, expected, tolerance
+       ERROR STOP 1
+    ENDIF
+  END SUBROUTINE assert_close
+
+  SUBROUTINE assert_true(condition, label)
+    LOGICAL, INTENT(IN) :: condition
+    CHARACTER(LEN=*), INTENT(IN) :: label
+    IF (.NOT. condition) THEN
+       WRITE (*, '(2A)') 'FAIL: ', TRIM(label)
+       ERROR STOP 1
+    ENDIF
+  END SUBROUTINE assert_true
+
+END PROGRAM test_magnetic_topology

--- a/unit_tests/fortran/test_magnetic_topology.f90
+++ b/unit_tests/fortran/test_magnetic_topology.f90
@@ -59,6 +59,15 @@ CONTAINS
     CALL assert_true(normal(1) > 0.999d0, 'limited outward normal')
     CALL geometry%evaluate_topology(r0 + 0.6d0, 0.d0, psi_n, rho, normal, region)
     CALL assert_true(region == magnetic_region_main_sol, 'limited SOL classification')
+
+    psi = -psi
+    CALL geometry%init(r, z, psi, ierr, message)
+    CALL assert_ok(ierr, message)
+    CALL geometry%analyze(-1.03d0*a*a, wall, faces, ref_nodes, ierr, message)
+    CALL assert_ok(ierr, message)
+    CALL geometry%evaluate_topology(r0 + 0.25d0, 0.d0, psi_n, rho, normal, region)
+    CALL assert_close(rho, 0.5d0, 2.d-5, 'reversed-flux normalized poloidal radius')
+    CALL assert_true(normal(1) > 0.999d0, 'reversed-flux outward normal')
   END SUBROUTINE test_limited_wall_contact
 
   SUBROUTINE test_limited_sharp_corner_contact()

--- a/unit_tests/fortran/test_magnetic_topology.f90
+++ b/unit_tests/fortran/test_magnetic_topology.f90
@@ -52,6 +52,8 @@ CONTAINS
     CALL assert_close(geometry%z_axis, 0.d0, 2.d-6, 'limited magnetic-axis Z')
     CALL assert_close(geometry%psi_lcfs, a*a, 2.d-6, 'wall-derived LCFS flux')
     CALL assert_close(geometry%a_minor, a, 2.d-5, 'wall-derived minor radius')
+    CALL assert_true(geometry%lcfs_extrema_refined, &
+         'limited LCFS extrema were not refined')
 
     CALL geometry%evaluate_topology(r0 + 0.25d0, 0.d0, psi_n, rho, normal, region)
     CALL assert_true(region == magnetic_region_core, 'limited core classification')
@@ -202,6 +204,8 @@ CONTAINS
     CALL assert_close(geometry%psi_lcfs, psi_x, 4.d-4, 'X-point LCFS flux')
     CALL assert_close(geometry%a_minor, SQRT(psi_x), 2.d-3, &
          'diverted LCFS half width')
+    CALL assert_true(geometry%lcfs_extrema_refined, &
+         'diverted LCFS extrema were not refined')
 
     CALL geometry%evaluate_topology(r0, 0.15d0, psi_n, rho, normal, region)
     CALL assert_true(region == magnetic_region_core, 'diverted core classification')

--- a/unit_tests/fortran/test_transport_region_policy.f90
+++ b/unit_tests/fortran/test_transport_region_policy.f90
@@ -1,0 +1,92 @@
+PROGRAM test_transport_region_policy
+  USE magnetic_topology, ONLY: magnetic_region_undefined, magnetic_region_core, &
+       magnetic_region_main_sol, magnetic_region_private_flux
+  USE transport_models_1d_config
+  IMPLICIT NONE
+
+  INTEGER :: policy
+  LOGICAL :: valid
+  REAL*8 :: velocity(2)
+
+  CALL tm1d_region_policy_from_name('legacy_all_regions', policy, valid)
+  CALL assert_true(valid, 'legacy policy parsing')
+  CALL assert_true(policy == transport_region_legacy_all_regions, &
+       'legacy policy identifier')
+  CALL assert_true(TRIM(tm1d_region_policy_name(policy)) == &
+       'legacy_all_regions', 'legacy policy name round trip')
+  CALL assert_true(tm1d_region_is_included(policy, magnetic_region_undefined), &
+       'legacy undefined inclusion')
+  CALL assert_true(tm1d_region_is_included(policy, magnetic_region_private_flux), &
+       'legacy private-flux inclusion')
+
+  CALL tm1d_region_policy_from_name('CORE_AND_MAIN_SOL', policy, valid)
+  CALL assert_true(valid, 'case-insensitive core-and-SOL parsing')
+  CALL assert_true(TRIM(tm1d_region_policy_name(policy)) == &
+       'core_and_main_sol', 'core-and-SOL name round trip')
+  CALL assert_true(tm1d_region_is_included(policy, magnetic_region_core), &
+       'core-and-SOL core inclusion')
+  CALL assert_true(tm1d_region_is_included(policy, magnetic_region_main_sol), &
+       'core-and-SOL main-SOL inclusion')
+  CALL assert_true(.NOT. tm1d_region_is_included(policy, magnetic_region_private_flux), &
+       'core-and-SOL private-flux exclusion')
+  CALL assert_true(.NOT. tm1d_region_is_included(policy, magnetic_region_undefined), &
+       'core-and-SOL undefined-region exclusion')
+
+  CALL tm1d_region_policy_from_name('core_only', policy, valid)
+  CALL assert_true(valid, 'core-only parsing')
+  CALL assert_true(TRIM(tm1d_region_policy_name(policy)) == &
+       'core_only', 'core-only name round trip')
+  CALL assert_true(tm1d_region_is_included(policy, magnetic_region_core), &
+       'core-only core inclusion')
+  CALL assert_true(.NOT. tm1d_region_is_included(policy, magnetic_region_main_sol), &
+       'core-only main-SOL exclusion')
+  CALL assert_true(.NOT. tm1d_region_is_included(policy, magnetic_region_private_flux), &
+       'core-only private-flux exclusion')
+
+  CALL tm1d_region_policy_from_name('not_a_policy', policy, valid)
+  CALL assert_true(.NOT. valid, 'invalid policy rejection')
+  CALL assert_true(TRIM(tm1d_region_policy_name(-1)) == 'unknown', &
+       'invalid policy formatting')
+
+  CALL tm1d_region_policy_from_name('core_and_main_sol', policy, valid)
+  CALL tm1d_build_pinch_velocity(2.d0, policy, [0.d0, 1.d0], &
+       [1.d0, 0.d0], velocity)
+  CALL assert_close(velocity(1), 2.d0, 'positive pinch is outward')
+  CALL assert_close(velocity(2), 0.d0, 'positive pinch has no tangential component')
+
+  CALL tm1d_build_pinch_velocity(-2.d0, policy, [0.d0, 1.d0], &
+       [1.d0, 0.d0], velocity)
+  CALL assert_close(velocity(1), -2.d0, 'negative pinch is inward')
+
+  CALL tm1d_build_pinch_velocity(2.d0, policy, [0.d0, 1.d0], &
+       [0.d0, 0.d0], velocity)
+  CALL assert_close(NORM2(velocity), 0.d0, 'null topology normal suppresses pinch')
+
+  CALL tm1d_build_pinch_velocity(2.d0, transport_region_legacy_all_regions, &
+       [0.d0, 1.d0], [0.d0, 0.d0], velocity)
+  CALL assert_close(velocity(1), 2.d0, 'legacy magnetic-field fallback')
+  WRITE (*, '(A)') 'transport region policy checks: PASS'
+
+CONTAINS
+
+  SUBROUTINE assert_true(condition, label)
+    LOGICAL, INTENT(IN) :: condition
+    CHARACTER(LEN=*), INTENT(IN) :: label
+
+    IF (.NOT. condition) THEN
+       WRITE (*, '(2A)') 'FAIL: ', TRIM(label)
+       ERROR STOP 1
+    ENDIF
+  END SUBROUTINE assert_true
+
+  SUBROUTINE assert_close(value, expected, label)
+    REAL*8, INTENT(IN) :: value, expected
+    CHARACTER(LEN=*), INTENT(IN) :: label
+
+    IF (ABS(value - expected) > 1.d-12) THEN
+       WRITE (*, '(A,1X,A,2(1X,ES12.4))') 'FAIL:', TRIM(label), value, expected
+       ERROR STOP 1
+    ENDIF
+  END SUBROUTINE assert_close
+
+END PROGRAM test_transport_region_policy

--- a/unit_tests/fortran/test_transport_taper.f90
+++ b/unit_tests/fortran/test_transport_taper.f90
@@ -1,0 +1,37 @@
+PROGRAM test_transport_taper
+  USE transport_models_1d_config, ONLY: transport_model_config_t, &
+       tm1d_config_reset, tm1d_config_apply, tm1d_particle_taper_factor
+  IMPLICIT NONE
+
+  TYPE(transport_model_config_t) :: config
+  REAL*8 :: untapered, tapered, clipped
+
+  CALL assert_close(config%c_bohm_n_rho_slope, 0.7d0, 'initialized default slope')
+  CALL tm1d_config_reset(config)
+  CALL assert_close(config%c_bohm_n_rho_slope, 0.7d0, 'reset default slope')
+
+  CALL tm1d_config_apply(config, 1.d0, 1.d0, c_bohm_n_rho_slope=0.d0)
+  CALL assert_close(config%c_bohm_n_rho_slope, 0.d0, 'configured zero slope')
+
+  untapered = tm1d_particle_taper_factor(1.2d0, 0.d0)
+  tapered = tm1d_particle_taper_factor(1.2d0, 0.7d0)
+  clipped = tm1d_particle_taper_factor(2.d0, 0.7d0)
+  CALL assert_close(untapered, 1.d0, 'zero slope is exactly untapered')
+  CALL assert_close(tapered, 0.16d0, 'default slope at rho above one')
+  CALL assert_close(clipped, 0.d0, 'particle taper lower-bound clipping')
+
+  WRITE (*, '(A)') 'transport particle taper checks: PASS'
+
+CONTAINS
+
+  SUBROUTINE assert_close(value, expected, label)
+    REAL*8, INTENT(IN) :: value, expected
+    CHARACTER(LEN=*), INTENT(IN) :: label
+
+    IF (ABS(value - expected) > 1.d-12) THEN
+       WRITE (*, '(A,1X,A,2(1X,ES12.4))') 'FAIL:', TRIM(label), value, expected
+       ERROR STOP 1
+    ENDIF
+  END SUBROUTINE assert_close
+
+END PROGRAM test_transport_taper


### PR DESCRIPTION
This PR makes 1D transport mesh-independent and safe for limited and lower-single-null equilibria.

- Adds bicubic psi geometry with magnetic-axis, X-point, wall-contact LCFS, minor-radius, and topology-region detection.
- Classifies `core`, `main_sol`, `private_flux`, and `undefined` independently of normalized flux.
- Caches rho, regions, and outward normals at nodes and HDG quadrature points.
- Makes `compute_from_flux=.true.` the default and fits the psi-to-Bpol sign/scaling against stored fields.
- Derives core Jtor from psi with an automatically selected sign convention.
- Adds `legacy_all_regions`, `core_and_main_sol`, and `core_only` transport policies.
- Replaces geometric `r/a` usage with normalized poloidal flux and topology-safe pinch direction.
- Ports the bounded Bohm/GyroBohm particle-diffusion taper with default slope `0.7`.
- Saves topology, geometry, normalized flux, region IDs, and magnetic consistency diagnostics to HDF5.

Validation includes focused limited/diverted tests and accepted limited and diverted golden campaigns covering warm, cold/adaptive, layout, race, and impurity workflows.
